### PR TITLE
feat(studio): add observability MVP with registry threads and persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,85 @@ end
 
 Start your server and visit `/studio`.
 
+## Setup
+
+Use this sequence for a clean first-time setup.
+
+### 1. Install the dependency
+
+```elixir
+def deps do
+  [
+    {:jido_studio, "~> 0.1.0"}
+  ]
+end
+```
+
+Then fetch dependencies:
+
+```bash
+mix deps.get
+```
+
+### 2. Configure Studio
+
+Set your Jido supervisor module so Studio can show running instances (without this, Studio still shows discovered modules only):
+
+```elixir
+# config/config.exs
+config :jido_studio,
+  jido_instance: MyApp.Jido
+```
+
+Default observability persistence is ETS and needs no extra setup:
+
+```elixir
+config :jido_studio, :persistence,
+  adapter: JidoStudio.Persistence.ETS,
+  opts: []
+```
+
+### 3. Mount in the Phoenix router
+
+```elixir
+# lib/my_app_web/router.ex
+import JidoStudio.Router
+
+scope "/" do
+  pipe_through [:browser, :require_authenticated_user]
+  jido_studio "/studio"
+end
+```
+
+### 4. (Optional) Use Postgres persistence for traces/spans
+
+Switch the persistence adapter:
+
+```elixir
+config :jido_studio, :persistence,
+  adapter: JidoStudio.Persistence.Ecto,
+  opts: [repo: MyApp.Repo, prefix: "public"]
+```
+
+Copy the provided migration template into your host app and run:
+
+```bash
+mix ecto.migrate
+```
+
+Template:
+
+- `priv/ecto/migrations/20260215000000_create_jido_studio_persistence_tables.exs`
+
+### 5. Run and verify
+
+Start Phoenix and open `/studio`. For MVP pages, verify:
+
+- `Agents` (live runtime and debug toggle)
+- `Registry` (discovery catalog)
+- `Threads` (persisted thread/memory explorer)
+- `Traces` (trace list + detail timeline)
+
 ## Runtime Installation Modes
 
 ### Mode 1: Auto Runtime (default)
@@ -95,11 +174,34 @@ Notes:
 ## Features
 
 - **Agents** — Browse, inspect, and chat with running agents
-- **Actions** — View registered actions and their schemas
-- **Workflows** — Visualize and debug workflow execution
-- **Signals** — Monitor signal routing and delivery
-- **Traces** — View telemetry events with trace correlation
+- **Registry** — Discovery-powered catalog of agents/actions/sensors/plugins
+- **Threads** — Inspect persisted thread/memory entries
+- **Traces** — Trace list + span timeline explorer
 - **Settings** — Configure runtime behavior
+
+## Observability Persistence
+
+Trace and span observability data is stored via the Studio persistence adapter.
+
+Default (zero setup):
+
+```elixir
+config :jido_studio, :persistence,
+  adapter: JidoStudio.Persistence.ETS,
+  opts: []
+```
+
+Optional Ecto/Postgres adapter:
+
+```elixir
+config :jido_studio, :persistence,
+  adapter: JidoStudio.Persistence.Ecto,
+  opts: [repo: MyApp.Repo, prefix: "public"]
+```
+
+Migration template:
+
+- `priv/ecto/migrations/20260215000000_create_jido_studio_persistence_tables.exs`
 
 ## Access Control
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,1 +1,8 @@
 import Config
+
+config :jido_studio,
+  trace_preview_limit: 200,
+  persistence: [
+    adapter: JidoStudio.Persistence.ETS,
+    opts: []
+  ]

--- a/lib/jido_studio.ex
+++ b/lib/jido_studio.ex
@@ -29,9 +29,8 @@ defmodule JidoStudio do
   ## Features
 
   - **Agents** — Browse, inspect, and chat with running agents
-  - **Actions** — View registered actions and their schemas
-  - **Workflows** — Visualize and debug workflow execution
-  - **Signals** — Monitor signal routing and delivery
+  - **Registry** — Discovery-powered catalog of agents, actions, sensors, and plugins
+  - **Threads** — Inspect persisted thread/memory entries
   - **Traces** — View telemetry events with trace correlation
   - **Settings** — Configure runtime behavior
 
@@ -54,9 +53,13 @@ defmodule JidoStudio do
         thread_retention_days: 30,
         persist_strategy_context: :summary,
         trace_buffer_size: 5000,
-        trace_preview_limit: 30,
+        trace_preview_limit: 200,
         trace_page_limit: 300,
         trace_include_agent_debug: true,
+        persistence: [
+          adapter: JidoStudio.Persistence.ETS,
+          opts: []
+        ],
         trace_events: JidoStudio.TraceCatalog.default_events(),
         presenter_registry: %{
           MyApp.CustomAgent => MyApp.StudioPresenters.CustomAgent

--- a/lib/jido_studio/ingestor.ex
+++ b/lib/jido_studio/ingestor.ex
@@ -1,0 +1,284 @@
+defmodule JidoStudio.Ingestor do
+  @moduledoc false
+  use GenServer
+
+  alias JidoStudio.Persistence
+
+  @traces_namespace "traces"
+  @spans_namespace "spans"
+
+  @terminal_types [:stop, :exception]
+
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]},
+      type: :worker,
+      restart: :permanent,
+      shutdown: 5_000
+    }
+  end
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @spec ingest_event(map()) :: :ok
+  def ingest_event(event) when is_map(event) do
+    case Process.whereis(__MODULE__) do
+      pid when is_pid(pid) -> GenServer.cast(__MODULE__, {:ingest, event})
+      _ -> :ok
+    end
+
+    :ok
+  end
+
+  def ingest_event(_), do: :ok
+
+  @impl true
+  def init(_opts) do
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_cast({:ingest, event}, state) do
+    _ = persist_event(event)
+    {:noreply, state}
+  end
+
+  defp persist_event(event) do
+    trace_id = normalize_optional_string(event[:trace_id])
+
+    if is_binary(trace_id) do
+      _ = Persistence.append_event(trace_stream(trace_id), event)
+      _ = persist_trace_doc(trace_id, event)
+      _ = persist_span_doc(trace_id, event)
+    end
+
+    :ok
+  rescue
+    _ -> :ok
+  end
+
+  defp persist_trace_doc(trace_id, event) do
+    existing =
+      case Persistence.get_doc(@traces_namespace, trace_id) do
+        {:ok, doc} when is_map(doc) -> doc
+        _ -> %{id: trace_id, trace_id: trace_id}
+      end
+
+    timestamp = event_timestamp(event)
+    type = normalize_event_type(event[:type])
+
+    started_at =
+      existing
+      |> Map.get(:started_at)
+      |> min_timestamp(timestamp)
+
+    ended_at =
+      if type in @terminal_types do
+        max_timestamp(Map.get(existing, :ended_at), timestamp)
+      else
+        Map.get(existing, :ended_at)
+      end
+
+    status = normalize_status(Map.get(existing, :status), type)
+
+    error_payload =
+      if type == :exception do
+        normalize_metadata(Map.get(event, :metadata, %{}))
+      else
+        Map.get(existing, :error_payload)
+      end
+
+    span_ids =
+      existing
+      |> Map.get(:span_ids, [])
+      |> maybe_add_span_id(event[:span_id])
+      |> Enum.take(-300)
+
+    duration_ms =
+      case {started_at, ended_at} do
+        {start_ms, end_ms} when is_integer(start_ms) and is_integer(end_ms) ->
+          max(end_ms - start_ms, 0)
+
+        _ ->
+          nil
+      end
+
+    updated =
+      existing
+      |> Map.put(:trace_id, trace_id)
+      |> Map.put(
+        :agent_id,
+        normalize_optional_string(event[:agent_id]) || Map.get(existing, :agent_id)
+      )
+      |> Map.put(:status, status)
+      |> Map.put(:started_at, started_at || timestamp)
+      |> Map.put(:ended_at, ended_at)
+      |> Map.put(:duration_ms, duration_ms)
+      |> Map.put(:error, type == :exception or Map.get(existing, :error, false))
+      |> Map.put(:error_payload, error_payload)
+      |> Map.put(:last_event_at, timestamp)
+      |> Map.put(
+        :event_count,
+        normalize_non_negative_integer(Map.get(existing, :event_count), 0) + 1
+      )
+      |> Map.put(:span_ids, span_ids)
+      |> Map.put(:span_count, length(span_ids))
+      |> Map.put(
+        :call_id,
+        normalize_optional_string(event[:call_id]) || Map.get(existing, :call_id)
+      )
+      |> Map.put(
+        :causation_id,
+        normalize_optional_string(event[:causation_id]) || Map.get(existing, :causation_id)
+      )
+
+    Persistence.put_doc(@traces_namespace, trace_id, updated)
+  end
+
+  defp persist_span_doc(trace_id, event) do
+    span_id = normalize_optional_string(event[:span_id])
+
+    if is_binary(span_id) do
+      doc_id = "#{trace_id}:#{span_id}"
+
+      existing =
+        case Persistence.get_doc(@spans_namespace, doc_id) do
+          {:ok, doc} when is_map(doc) -> doc
+          _ -> %{id: doc_id, trace_id: trace_id, span_id: span_id}
+        end
+
+      timestamp = event_timestamp(event)
+      type = normalize_event_type(event[:type])
+
+      started_at =
+        existing
+        |> Map.get(:started_at)
+        |> min_timestamp(timestamp)
+
+      ended_at =
+        if type in @terminal_types do
+          max_timestamp(Map.get(existing, :ended_at), timestamp)
+        else
+          Map.get(existing, :ended_at)
+        end
+
+      duration_ms =
+        case {started_at, ended_at} do
+          {start_ms, end_ms} when is_integer(start_ms) and is_integer(end_ms) ->
+            max(end_ms - start_ms, 0)
+
+          _ ->
+            nil
+        end
+
+      updated =
+        existing
+        |> Map.put(:trace_id, trace_id)
+        |> Map.put(:span_id, span_id)
+        |> Map.put(:parent_span_id, normalize_optional_string(event[:parent_span_id]))
+        |> Map.put(:event_name, normalize_event_name(event))
+        |> Map.put(:agent_id, normalize_optional_string(event[:agent_id]))
+        |> Map.put(:status, normalize_status(Map.get(existing, :status), type))
+        |> Map.put(:started_at, started_at || timestamp)
+        |> Map.put(:ended_at, ended_at)
+        |> Map.put(:duration_ms, duration_ms)
+        |> Map.put(:last_event_at, timestamp)
+        |> Map.put(:error, type == :exception or Map.get(existing, :error, false))
+        |> Map.put(
+          :error_payload,
+          if(type == :exception,
+            do: normalize_metadata(event[:metadata]),
+            else: Map.get(existing, :error_payload)
+          )
+        )
+        |> Map.put(:metadata, normalize_metadata(event[:metadata]))
+
+      Persistence.put_doc(@spans_namespace, doc_id, updated)
+    else
+      :ok
+    end
+  end
+
+  defp normalize_event_type(type) when type in [:start, :stop, :exception], do: type
+
+  defp normalize_event_type(type) when is_binary(type) do
+    case String.downcase(type) do
+      "start" -> :start
+      "stop" -> :stop
+      "exception" -> :exception
+      _ -> :event
+    end
+  end
+
+  defp normalize_event_type(_), do: :event
+
+  defp normalize_status(_existing_status, :exception), do: "error"
+  defp normalize_status("error", :stop), do: "error"
+  defp normalize_status(_existing_status, :stop), do: "ok"
+  defp normalize_status(nil, :start), do: "running"
+  defp normalize_status(nil, _), do: "running"
+  defp normalize_status(existing_status, _), do: existing_status
+
+  defp normalize_event_name(event) when is_map(event) do
+    cond do
+      is_binary(event[:event_name]) ->
+        event[:event_name]
+
+      is_list(event[:event_prefix]) ->
+        Enum.join(event[:event_prefix], ".")
+
+      true ->
+        "event"
+    end
+  end
+
+  defp normalize_event_name(_), do: "event"
+
+  defp normalize_metadata(map) when is_map(map), do: map
+  defp normalize_metadata(_), do: %{}
+
+  defp event_timestamp(event) when is_map(event) do
+    case event[:timestamp_ms] do
+      value when is_integer(value) -> value
+      _ -> System.system_time(:millisecond)
+    end
+  end
+
+  defp event_timestamp(_), do: System.system_time(:millisecond)
+
+  defp maybe_add_span_id(span_ids, nil), do: span_ids
+
+  defp maybe_add_span_id(span_ids, span_id) do
+    id = normalize_optional_string(span_id)
+
+    if is_binary(id) and not Enum.member?(span_ids, id) do
+      span_ids ++ [id]
+    else
+      span_ids
+    end
+  end
+
+  defp trace_stream(trace_id), do: "trace:" <> trace_id
+
+  defp normalize_optional_string(value) when is_binary(value) and value != "", do: value
+  defp normalize_optional_string(value) when is_atom(value), do: Atom.to_string(value)
+  defp normalize_optional_string(_), do: nil
+
+  defp normalize_non_negative_integer(value, _default) when is_integer(value) and value >= 0,
+    do: value
+
+  defp normalize_non_negative_integer(_value, default), do: default
+
+  defp min_timestamp(nil, rhs), do: rhs
+  defp min_timestamp(lhs, nil), do: lhs
+  defp min_timestamp(lhs, rhs), do: min(lhs, rhs)
+
+  defp max_timestamp(nil, rhs), do: rhs
+  defp max_timestamp(lhs, nil), do: lhs
+  defp max_timestamp(lhs, rhs), do: max(lhs, rhs)
+end

--- a/lib/jido_studio/layouts.ex
+++ b/lib/jido_studio/layouts.ex
@@ -127,25 +127,18 @@ defmodule JidoStudio.Layouts do
               icon="agents"
             />
             <.nav_item
-              path="/actions"
-              label="Actions"
+              path="/registry"
+              label="Registry"
               current_path={@current_path}
               prefix={@prefix}
-              icon="actions"
+              icon="registry"
             />
             <.nav_item
-              path="/workflows"
-              label="Workflows"
+              path="/threads"
+              label="Threads"
               current_path={@current_path}
               prefix={@prefix}
-              icon="workflows"
-            />
-            <.nav_item
-              path="/signals"
-              label="Signals"
-              current_path={@current_path}
-              prefix={@prefix}
-              icon="signals"
+              icon="threads"
             />
             <.nav_item
               path="/traces"
@@ -222,21 +215,15 @@ defmodule JidoStudio.Layouts do
     """
   end
 
-  defp nav_icon(%{name: "actions"} = assigns) do
+  defp nav_icon(%{name: "registry"} = assigns) do
     ~H"""
     <Lucideicons.zap class="w-[18px] h-[18px] shrink-0" />
     """
   end
 
-  defp nav_icon(%{name: "workflows"} = assigns) do
+  defp nav_icon(%{name: "threads"} = assigns) do
     ~H"""
     <Lucideicons.git_branch class="w-[18px] h-[18px] shrink-0" />
-    """
-  end
-
-  defp nav_icon(%{name: "signals"} = assigns) do
-    ~H"""
-    <Lucideicons.radio class="w-[18px] h-[18px] shrink-0" />
     """
   end
 

--- a/lib/jido_studio/live/agents_live.ex
+++ b/lib/jido_studio/live/agents_live.ex
@@ -63,6 +63,8 @@ defmodule JidoStudio.AgentsLive do
       |> assign(:starting_instance?, false)
       |> assign(:trace_preview_limit, Observability.trace_preview_limit())
       |> assign(:trace_include_agent_debug?, Observability.trace_include_agent_debug?())
+      |> assign(:live_event_query, "")
+      |> assign(:live_event_limit, 200)
       |> assign(:instance_observability_events, [])
       |> assign(:instance_debug_events, [])
       |> assign(:instance_telemetry_events, [])
@@ -203,6 +205,11 @@ defmodule JidoStudio.AgentsLive do
     error ->
       {:noreply,
        put_flash(socket, :error, "Failed to toggle debug mode: #{Exception.message(error)}")}
+  end
+
+  @impl true
+  def handle_event("update_live_event_query", %{"query" => query}, socket) do
+    {:noreply, assign(socket, :live_event_query, String.trim(query || ""))}
   end
 
   @impl true
@@ -651,7 +658,9 @@ defmodule JidoStudio.AgentsLive do
           )
 
         start_form_schema = presenter_start_form_schema(presenter, agent)
-        traces_path = traces_path(socket.assigns.prefix, agent, active_instance_id, active_instance_id)
+
+        traces_path =
+          traces_path(socket.assigns.prefix, agent, active_instance_id, active_instance_id)
 
         view_model =
           presenter_view_model(
@@ -879,6 +888,7 @@ defmodule JidoStudio.AgentsLive do
       when not is_nil(agent) and action == :show and not is_nil(active_instance_id) do
     workbench_tab = assigns.workbench_tab || :chat
     summary_visible? = workbench_tab != :instance
+
     context_sections =
       thread_context_sections(
         assigns.sections_by_tab,
@@ -886,8 +896,16 @@ defmodule JidoStudio.AgentsLive do
         assigns.chat_state.active_thread_id,
         is_pid(assigns.active_instance_pid)
       )
+
     thread_scope_id = active_strategy_thread_id(assigns.runtime_status)
-    thread_events = thread_events_for_display(assigns.instance_observability_events, thread_scope_id)
+
+    thread_events =
+      thread_events_for_display(
+        assigns.instance_observability_events,
+        thread_scope_id,
+        assigns.live_event_query,
+        assigns.live_event_limit
+      )
 
     assigns =
       assigns
@@ -908,7 +926,12 @@ defmodule JidoStudio.AgentsLive do
       )
       |> assign(
         :instance_links,
-        instance_links(assigns.prefix, agent, assigns.running_instances, assigns.active_instance_id)
+        instance_links(
+          assigns.prefix,
+          agent,
+          assigns.running_instances,
+          assigns.active_instance_id
+        )
       )
       |> assign(:summary_meta, summary_meta(assigns.runtime_status, assigns.ui_model))
 
@@ -1032,6 +1055,15 @@ defmodule JidoStudio.AgentsLive do
                   </.link>
                 </div>
                 <div class="p-3 overflow-y-auto overflow-x-hidden js-scroll space-y-2.5 flex-1 min-h-0">
+                  <form phx-change="update_live_event_query" class="mb-2">
+                    <input
+                      type="text"
+                      name="query"
+                      value={@live_event_query}
+                      placeholder="Search events"
+                      class="w-full rounded-md border border-js-border bg-js-bg-elevated px-2 py-1.5 text-xs text-js-text focus:outline-none focus:ring-2 focus:ring-js-ring"
+                    />
+                  </form>
                   <p :if={@thread_scope_id} class="text-xs text-js-text-subtle">
                     Thread ID: <span class="font-mono text-js-text">{@thread_scope_id}</span>
                   </p>
@@ -1049,7 +1081,9 @@ defmodule JidoStudio.AgentsLive do
                         <span class="text-[11px] font-mono text-js-text-subtle">
                           {format_event_timestamp(event[:timestamp_ms])}
                         </span>
-                        <.badge variant={if(event[:source] == :agent_debug, do: :warning, else: :info)}>
+                        <.badge variant={
+                          if(event[:source] == :agent_debug, do: :warning, else: :info)
+                        }>
                           {event[:source] || :telemetry}
                         </.badge>
                       </div>
@@ -1703,7 +1737,8 @@ defmodule JidoStudio.AgentsLive do
       end)
 
     if is_binary(active_instance_id) and not Enum.any?(links, &(&1.id == active_instance_id)) do
-      links ++ [%{id: active_instance_id, path: agent_instance_path(prefix, agent, active_instance_id)}]
+      links ++
+        [%{id: active_instance_id, path: agent_instance_path(prefix, agent, active_instance_id)}]
     else
       links
     end
@@ -2158,7 +2193,8 @@ defmodule JidoStudio.AgentsLive do
   end
 
   defp schedule_workspace_persist(socket, reason, delay_ms \\ 0) do
-    has_workspace? = is_binary(socket.assigns[:active_instance_id]) and not is_nil(socket.assigns[:agent])
+    has_workspace? =
+      is_binary(socket.assigns[:active_instance_id]) and not is_nil(socket.assigns[:agent])
 
     cond do
       socket.assigns[:thread_persistence?] != true ->
@@ -2282,13 +2318,15 @@ defmodule JidoStudio.AgentsLive do
   defp snapshot_status(_), do: :unknown
 
   defp detail_value(details, key, default \\ nil)
+
   defp detail_value(details, key, default) when is_map(details) and is_atom(key) do
     Map.get(details, key, Map.get(details, Atom.to_string(key), default))
   end
 
   defp detail_value(_, _, default), do: default
 
-  defp ensure_workspace_chat_state(%{threads: []} = _state), do: ChatSession.with_initial_thread("New Chat")
+  defp ensure_workspace_chat_state(%{threads: []} = _state),
+    do: ChatSession.with_initial_thread("New Chat")
 
   defp ensure_workspace_chat_state(%{} = state) do
     %{
@@ -2382,8 +2420,9 @@ defmodule JidoStudio.AgentsLive do
 
   defp parse_workbench_tab(panel, legacy_view \\ nil)
 
-  defp parse_workbench_tab(panel, _legacy_view) when panel in [:chat, :thread_context, :thread_events, :instance],
-    do: panel
+  defp parse_workbench_tab(panel, _legacy_view)
+       when panel in [:chat, :thread_context, :thread_events, :instance],
+       do: panel
 
   defp parse_workbench_tab("chat", _legacy_view), do: :chat
   defp parse_workbench_tab("thread_context", _legacy_view), do: :thread_context
@@ -2423,12 +2462,19 @@ defmodule JidoStudio.AgentsLive do
   defp tab_query_value(tab) when is_binary(tab) and tab != "", do: tab
   defp tab_query_value(_), do: nil
 
-  defp thread_context_sections(sections_by_tab, persisted_contexts, active_thread_id, instance_online?)
+  defp thread_context_sections(
+         sections_by_tab,
+         persisted_contexts,
+         active_thread_id,
+         instance_online?
+       )
        when is_map(sections_by_tab) do
     context = Map.get(sections_by_tab, :context, [])
     reasoning = Map.get(sections_by_tab, :reasoning, [])
     overview = Map.get(sections_by_tab, :overview, [])
-    persisted = persisted_thread_context_sections(persisted_contexts, active_thread_id, instance_online?)
+
+    persisted =
+      persisted_thread_context_sections(persisted_contexts, active_thread_id, instance_online?)
 
     sections = context ++ reasoning ++ overview ++ persisted
 
@@ -2445,7 +2491,11 @@ defmodule JidoStudio.AgentsLive do
          %{} = snapshot <- Map.get(contexts, active_thread_id) do
       summary_rows =
         [
-          {"Source", if(instance_online?, do: "Persisted snapshot (live available)", else: "Persisted snapshot (instance offline)")},
+          {"Source",
+           if(instance_online?,
+             do: "Persisted snapshot (live available)",
+             else: "Persisted snapshot (instance offline)"
+           )},
           {"Captured At", format_event_timestamp(Map.get(snapshot, :captured_at))},
           {"Status", to_string(Map.get(snapshot, :status, "unknown"))},
           {"Strategy Thread", to_string(Map.get(snapshot, :strategy_thread_id, "n/a"))},
@@ -2490,7 +2540,7 @@ defmodule JidoStudio.AgentsLive do
 
   defp active_strategy_thread_id(_), do: nil
 
-  defp thread_events_for_display(events, thread_id) when is_list(events) do
+  defp thread_events_for_display(events, thread_id, query, limit) when is_list(events) do
     filtered =
       if is_binary(thread_id) and thread_id != "" do
         Enum.filter(events, fn event ->
@@ -2510,10 +2560,11 @@ defmodule JidoStudio.AgentsLive do
       end
 
     selected
-    |> Enum.take(60)
+    |> filter_events_by_query(query)
+    |> Enum.take(normalize_thread_event_limit(limit))
   end
 
-  defp thread_events_for_display(_, _), do: []
+  defp thread_events_for_display(_, _, _, _), do: []
 
   defp event_thread_id(event) when is_map(event) do
     metadata = Map.get(event, :metadata, %{})
@@ -2521,6 +2572,47 @@ defmodule JidoStudio.AgentsLive do
   end
 
   defp event_thread_id(_), do: nil
+
+  defp filter_events_by_query(events, query) when is_list(events) do
+    case normalize_optional_query(query) do
+      nil ->
+        events
+
+      normalized ->
+        Enum.filter(events, fn event ->
+          haystack =
+            [
+              format_event_name(event),
+              inspect(event[:metadata] || %{}, limit: 5),
+              to_string(event[:type] || ""),
+              to_string(event[:source] || ""),
+              to_string(event[:trace_id] || ""),
+              to_string(event[:span_id] || "")
+            ]
+            |> Enum.join(" ")
+            |> String.downcase()
+
+          String.contains?(haystack, normalized)
+        end)
+    end
+  end
+
+  defp filter_events_by_query(events, _), do: events
+
+  defp normalize_optional_query(query) when is_binary(query) do
+    query
+    |> String.trim()
+    |> String.downcase()
+    |> case do
+      "" -> nil
+      value -> value
+    end
+  end
+
+  defp normalize_optional_query(_), do: nil
+
+  defp normalize_thread_event_limit(value) when is_integer(value) and value > 0, do: value
+  defp normalize_thread_event_limit(_), do: 200
 
   defp ordered_detail_tabs(tabs) when is_list(tabs) do
     desired = [:overview, :reasoning, :context, :weather, :model, :memory, :tracing]
@@ -2540,7 +2632,9 @@ defmodule JidoStudio.AgentsLive do
   defp ordered_detail_tabs(_), do: [%{id: :overview, label: "Overview"}]
 
   defp summary_meta(runtime_status, model_label) do
-    details = runtime_status && runtime_status.snapshot && runtime_status.snapshot.details || %{}
+    details =
+      (runtime_status && runtime_status.snapshot && runtime_status.snapshot.details) || %{}
+
     status = runtime_status && runtime_status.snapshot && runtime_status.snapshot.status
 
     [

--- a/lib/jido_studio/live/registry_live.ex
+++ b/lib/jido_studio/live/registry_live.ex
@@ -1,0 +1,250 @@
+defmodule JidoStudio.RegistryLive do
+  @moduledoc false
+  use Phoenix.LiveView
+
+  import JidoStudio.Components
+
+  @tabs ["agents", "actions", "sensors", "plugins"]
+
+  @impl true
+  def mount(_params, _session, socket) do
+    socket =
+      socket
+      |> assign(:page_title, "Registry")
+      |> assign(:tabs, @tabs)
+      |> assign(:tab, "agents")
+      |> assign(:query, "")
+      |> assign(:items, [])
+      |> assign(:selected_slug, nil)
+      |> assign(:selected_item, nil)
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(params, _uri, socket) do
+    tab = normalize_tab(params["tab"])
+    query = normalize_optional_string(params["q"]) || ""
+    selected_slug = normalize_optional_string(params["selected"])
+
+    items = list_tab_items(tab, query)
+    selected_item = Enum.find(items, &(&1[:slug] == selected_slug)) || List.first(items)
+
+    {:noreply,
+     socket
+     |> assign(:tab, tab)
+     |> assign(:query, query)
+     |> assign(:items, items)
+     |> assign(:selected_slug, selected_item && selected_item[:slug])
+     |> assign(:selected_item, selected_item)}
+  end
+
+  @impl true
+  def handle_event("search", %{"q" => query}, socket) do
+    {:noreply,
+     push_patch(socket,
+       to: path(socket.assigns.prefix, socket.assigns.tab, query, socket.assigns.selected_slug)
+     )}
+  end
+
+  @impl true
+  def handle_event("select", %{"slug" => slug}, socket) do
+    {:noreply,
+     push_patch(socket,
+       to: path(socket.assigns.prefix, socket.assigns.tab, socket.assigns.query, slug)
+     )}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="p-6 space-y-6">
+      <.page_header title="Registry" subtitle="Discovery-powered catalog of Jido runtime capabilities">
+        <:actions>
+          <form phx-change="search" class="flex items-center gap-2">
+            <input
+              type="text"
+              name="q"
+              value={@query}
+              placeholder="Search registry"
+              class="w-64 rounded-md border border-js-border bg-js-bg-elevated px-3 py-1.5 text-xs text-js-text focus:outline-none focus:ring-2 focus:ring-js-ring"
+            />
+          </form>
+        </:actions>
+      </.page_header>
+
+      <div class="inline-flex rounded-lg border border-js-border p-1 bg-js-bg-elevated">
+        <.link
+          :for={tab <- @tabs}
+          navigate={path(@prefix, tab, @query, @selected_slug)}
+          class={[
+            "px-3 py-1.5 rounded-md text-xs font-medium transition-colors",
+            if(@tab == tab,
+              do: "bg-js-card text-js-text",
+              else: "text-js-text-muted hover:text-js-text"
+            )
+          ]}
+        >
+          {String.capitalize(tab)}
+        </.link>
+      </div>
+
+      <div class="grid grid-cols-1 xl:grid-cols-[minmax(0,2fr)_minmax(0,1fr)] gap-4">
+        <.card class="p-0 overflow-hidden">
+          <div :if={@items == []} class="p-6">
+            <.empty_state
+              title="No components found"
+              description="Try another search or ensure Jido.Discovery has initialized for your runtime."
+            />
+          </div>
+
+          <div :if={@items != []} class="divide-y divide-js-border">
+            <button
+              :for={item <- @items}
+              type="button"
+              phx-click="select"
+              phx-value-slug={item[:slug]}
+              class={[
+                "w-full text-left px-4 py-3 transition-colors",
+                if(item[:slug] == @selected_slug,
+                  do: "bg-js-bg-elevated/60",
+                  else: "hover:bg-js-bg-elevated/40"
+                )
+              ]}
+            >
+              <div class="flex items-center justify-between gap-3">
+                <div class="min-w-0">
+                  <div class="text-sm text-js-text truncate">
+                    {item[:name] || inspect(item[:module])}
+                  </div>
+                  <div class="text-xs text-js-text-subtle font-mono truncate">
+                    {inspect(item[:module])}
+                  </div>
+                </div>
+                <.badge variant={:default}>{item[:category] || "n/a"}</.badge>
+              </div>
+              <p class="mt-1 text-xs text-js-text-muted line-clamp-2">{item[:description] || ""}</p>
+            </button>
+          </div>
+        </.card>
+
+        <.card>
+          <%= if @selected_item do %>
+            <div class="space-y-3 text-xs">
+              <div class="text-sm font-semibold text-js-text">
+                {@selected_item[:name] || inspect(@selected_item[:module])}
+              </div>
+              <div class="text-js-text-subtle font-mono break-all">
+                {inspect(@selected_item[:module])}
+              </div>
+              <p class="text-js-text-muted">
+                {@selected_item[:description] || "No description provided."}
+              </p>
+
+              <div class="flex flex-wrap gap-2">
+                <.badge variant={:info}>slug:{@selected_item[:slug]}</.badge>
+                <.badge variant={:default}>category:{@selected_item[:category] || "n/a"}</.badge>
+                <.badge :for={tag <- List.wrap(@selected_item[:tags] || [])} variant={:warning}>
+                  {to_string(tag)}
+                </.badge>
+              </div>
+
+              <div class="pt-2 border-t border-js-border">
+                <div class="text-[11px] uppercase tracking-wider text-js-text-subtle mb-1">
+                  Metadata
+                </div>
+                <pre class="text-xs text-js-text-muted bg-js-bg-elevated border border-js-border rounded-md p-2 whitespace-pre-wrap break-words"><%= inspect(Map.drop(@selected_item, [:description]), pretty: true, limit: 50, printable_limit: 8000) %></pre>
+              </div>
+
+              <div class="pt-2 border-t border-js-border">
+                <div class="text-[11px] uppercase tracking-wider text-js-text-subtle mb-1">
+                  Schema Hint
+                </div>
+                <pre class="text-xs text-js-text-muted bg-js-bg-elevated border border-js-border rounded-md p-2 whitespace-pre-wrap break-words"><%= schema_hint(@selected_item[:module]) %></pre>
+              </div>
+            </div>
+          <% else %>
+            <.empty_state
+              title="Select a component"
+              description="Choose an item from the registry list."
+            />
+          <% end %>
+        </.card>
+      </div>
+    </div>
+    """
+  end
+
+  defp list_tab_items("agents", query), do: apply_discovery(:list_agents, query)
+  defp list_tab_items("actions", query), do: apply_discovery(:list_actions, query)
+  defp list_tab_items("sensors", query), do: apply_discovery(:list_sensors, query)
+  defp list_tab_items("plugins", query), do: apply_discovery(:list_plugins, query)
+  defp list_tab_items(_, query), do: apply_discovery(:list_agents, query)
+
+  defp apply_discovery(fun, query) do
+    args = if query == "", do: [[]], else: [[name: query]]
+
+    case apply(Jido.Discovery, fun, args) do
+      items when is_list(items) -> Enum.sort_by(items, &to_string(&1[:name] || ""))
+      _ -> []
+    end
+  rescue
+    _ -> []
+  end
+
+  defp normalize_tab(tab) when tab in @tabs, do: tab
+  defp normalize_tab(_), do: "agents"
+
+  defp path(prefix, tab, query, selected_slug) do
+    params =
+      %{}
+      |> maybe_put_param("tab", tab)
+      |> maybe_put_param("q", normalize_optional_string(query))
+      |> maybe_put_param("selected", normalize_optional_string(selected_slug))
+
+    if map_size(params) == 0 do
+      prefix <> "/registry"
+    else
+      prefix <> "/registry?" <> URI.encode_query(params)
+    end
+  end
+
+  defp maybe_put_param(params, _key, nil), do: params
+  defp maybe_put_param(params, key, value), do: Map.put(params, key, value)
+
+  defp normalize_optional_string(value) when is_binary(value) do
+    normalized = String.trim(value)
+    if normalized == "", do: nil, else: normalized
+  end
+
+  defp normalize_optional_string(_), do: nil
+
+  defp schema_hint(module) when is_atom(module) do
+    cond do
+      function_exported?(module, :schema, 0) ->
+        inspect(apply(module, :schema, []), pretty: true, limit: 60)
+
+      function_exported?(module, :input_schema, 0) ->
+        inspect(apply(module, :input_schema, []), pretty: true, limit: 60)
+
+      function_exported?(module, :__action_metadata__, 0) ->
+        inspect(apply(module, :__action_metadata__, []), pretty: true, limit: 60)
+
+      function_exported?(module, :__sensor_metadata__, 0) ->
+        inspect(apply(module, :__sensor_metadata__, []), pretty: true, limit: 60)
+
+      function_exported?(module, :__agent_metadata__, 0) ->
+        inspect(apply(module, :__agent_metadata__, []), pretty: true, limit: 60)
+
+      function_exported?(module, :__plugin_metadata__, 0) ->
+        inspect(apply(module, :__plugin_metadata__, []), pretty: true, limit: 60)
+
+      true ->
+        "No explicit schema exported"
+    end
+  rescue
+    _ -> "No explicit schema exported"
+  end
+
+  defp schema_hint(_), do: "No explicit schema exported"
+end

--- a/lib/jido_studio/live/settings_live.ex
+++ b/lib/jido_studio/live/settings_live.ex
@@ -13,7 +13,10 @@ defmodule JidoStudio.SettingsLive do
       socket
       |> assign(:page_title, "Settings")
       |> assign(:trace_buffer_size, Application.get_env(:jido_studio, :trace_buffer_size, 5000))
-      |> assign(:trace_preview_limit, Application.get_env(:jido_studio, :trace_preview_limit, 30))
+      |> assign(
+        :trace_preview_limit,
+        Application.get_env(:jido_studio, :trace_preview_limit, 200)
+      )
       |> assign(:trace_page_limit, Application.get_env(:jido_studio, :trace_page_limit, 300))
       |> assign(
         :trace_include_agent_debug,
@@ -21,7 +24,10 @@ defmodule JidoStudio.SettingsLive do
       )
       |> assign(:trace_event_catalog_size, length(JidoStudio.TraceBuffer.event_catalog()))
       |> assign(:observability_debug_events, Keyword.get(observability, :debug_events, :off))
-      |> assign(:observability_redact_sensitive, Keyword.get(observability, :redact_sensitive, false))
+      |> assign(
+        :observability_redact_sensitive,
+        Keyword.get(observability, :redact_sensitive, false)
+      )
       |> assign(:pubsub, Application.get_env(:jido_studio, :pubsub, "Not configured"))
       |> assign(:thread_persistence, ThreadsStorage.persistence_enabled?())
       |> assign(:thread_storage_mode, ThreadsStorage.thread_storage_mode())
@@ -29,6 +35,15 @@ defmodule JidoStudio.SettingsLive do
       |> assign(:thread_retention_days, ThreadsStorage.thread_retention_days())
       |> assign(:persist_strategy_context, ThreadsStorage.persist_strategy_context_mode())
       |> assign(:auto_start_runtime, ThreadsStorage.auto_start_runtime?())
+      |> assign(:persistence_adapter, inspect(JidoStudio.Persistence.adapter()))
+      |> assign(
+        :persistence_opts,
+        JidoStudio.Persistence.resolve_adapter()
+        |> case do
+          {:ok, {_adapter, opts}} -> inspect(opts)
+          _ -> "[]"
+        end
+      )
 
     {:ok, socket}
   end
@@ -51,6 +66,7 @@ defmodule JidoStudio.SettingsLive do
         <.stat_card label="Trace Page Limit" value={to_string(@trace_page_limit)} />
         <.stat_card label="Thread Persistence" value={if(@thread_persistence, do: "On", else: "Off")} />
         <.stat_card label="Thread Storage Mode" value={to_string(@thread_storage_mode)} />
+        <.stat_card label="Persistence Adapter" value={@persistence_adapter} />
       </div>
 
       <.card>
@@ -76,7 +92,9 @@ defmodule JidoStudio.SettingsLive do
           </div>
           <div class="flex justify-between items-center py-2 border-b border-js-border">
             <span class="text-sm text-js-text-muted">Include Agent Debug Stream</span>
-            <span class="text-sm text-js-text font-mono">{to_string(@trace_include_agent_debug)}</span>
+            <span class="text-sm text-js-text font-mono">
+              {to_string(@trace_include_agent_debug)}
+            </span>
           </div>
           <div class="flex justify-between items-center py-2 border-b border-js-border">
             <span class="text-sm text-js-text-muted">Thread Persistence</span>
@@ -89,6 +107,14 @@ defmodule JidoStudio.SettingsLive do
           <div class="flex justify-between items-center py-2 border-b border-js-border">
             <span class="text-sm text-js-text-muted">Thread Storage</span>
             <span class="text-sm text-js-text font-mono">{@thread_storage}</span>
+          </div>
+          <div class="flex justify-between items-center py-2 border-b border-js-border">
+            <span class="text-sm text-js-text-muted">Persistence Adapter</span>
+            <span class="text-sm text-js-text font-mono">{@persistence_adapter}</span>
+          </div>
+          <div class="flex justify-between items-center py-2 border-b border-js-border">
+            <span class="text-sm text-js-text-muted">Persistence Adapter Opts</span>
+            <span class="text-sm text-js-text font-mono">{@persistence_opts}</span>
           </div>
           <div class="flex justify-between items-center py-2 border-b border-js-border">
             <span class="text-sm text-js-text-muted">Thread Retention (days)</span>

--- a/lib/jido_studio/live/threads_live.ex
+++ b/lib/jido_studio/live/threads_live.ex
@@ -1,0 +1,308 @@
+defmodule JidoStudio.ThreadsLive do
+  @moduledoc false
+  use Phoenix.LiveView
+
+  import JidoStudio.Components
+
+  alias JidoStudio.Threads
+
+  @impl true
+  def mount(_params, _session, socket) do
+    if connected?(socket), do: :timer.send_interval(3_000, self(), :refresh)
+
+    socket =
+      socket
+      |> assign(:page_title, "Threads")
+      |> assign(:query, "")
+      |> assign(:threads, [])
+      |> assign(:thread, nil)
+      |> assign(:entries, [])
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(params, _uri, socket) do
+    query = normalize_optional_string(params["q"]) || ""
+
+    threads =
+      Threads.list_threads(
+        query: query,
+        jido_instance: socket.assigns[:jido_instance]
+      )
+
+    socket =
+      socket
+      |> assign(:query, query)
+      |> assign(:threads, threads)
+
+    case socket.assigns.live_action do
+      :show ->
+        agent_slug = decode_segment(params["agent_slug"])
+        instance_id = decode_segment(params["instance_id"])
+        thread_id = decode_segment(params["thread_id"])
+
+        case Threads.get_thread(agent_slug, instance_id, thread_id,
+               jido_instance: socket.assigns[:jido_instance]
+             ) do
+          {:ok, payload} ->
+            {:noreply,
+             socket
+             |> assign(:thread, payload.thread)
+             |> assign(:entries, payload.entries)}
+
+          _ ->
+            {:noreply,
+             socket
+             |> put_flash(:error, "Thread not found")
+             |> assign(:thread, nil)
+             |> assign(:entries, [])}
+        end
+
+      _ ->
+        {:noreply, socket |> assign(:thread, nil) |> assign(:entries, [])}
+    end
+  end
+
+  @impl true
+  def handle_event("search", %{"q" => query}, socket) do
+    query = normalize_optional_string(query) || ""
+
+    {:noreply,
+     push_patch(socket,
+       to:
+         query_path(
+           socket.assigns.prefix,
+           query,
+           socket.assigns.live_action,
+           socket.assigns.thread
+         )
+     )}
+  end
+
+  @impl true
+  def handle_info(:refresh, socket) do
+    threads =
+      Threads.list_threads(
+        query: socket.assigns.query,
+        jido_instance: socket.assigns[:jido_instance]
+      )
+
+    {:noreply, assign(socket, :threads, threads)}
+  end
+
+  @impl true
+  def render(%{live_action: :show} = assigns) do
+    ~H"""
+    <div class="p-6 space-y-6">
+      <.page_header title="Threads" subtitle="Inspect persisted thread and memory entries">
+        <:actions>
+          <.link
+            navigate={list_path(@prefix, @query)}
+            class="inline-flex items-center gap-2 rounded-md border border-js-border px-3 py-1.5 text-xs text-js-text-muted hover:text-js-text hover:bg-js-bg-elevated transition-colors"
+          >
+            Back to Threads
+          </.link>
+        </:actions>
+      </.page_header>
+
+      <.card :if={is_nil(@thread)}>
+        <.empty_state
+          title="Thread not available"
+          description="The selected thread could not be loaded from storage."
+        />
+      </.card>
+
+      <%= if @thread do %>
+        <div class="grid grid-cols-1 lg:grid-cols-4 gap-4">
+          <.card class="lg:col-span-1">
+            <div class="space-y-2 text-xs text-js-text-muted">
+              <div>
+                <span class="text-js-text-subtle">Thread:</span> <code>{@thread.thread_id}</code>
+              </div>
+              <div><span class="text-js-text-subtle">Agent:</span> {@thread.agent_slug}</div>
+              <div>
+                <span class="text-js-text-subtle">Instance:</span> <code>{@thread.instance_id}</code>
+              </div>
+              <div><span class="text-js-text-subtle">Revision:</span> {@thread.rev}</div>
+              <div><span class="text-js-text-subtle">Entries:</span> {@thread.entry_count}</div>
+            </div>
+          </.card>
+
+          <.card class="lg:col-span-3 p-0 overflow-hidden">
+            <div class="overflow-x-auto">
+              <table class="w-full">
+                <thead>
+                  <tr class="border-b border-js-border">
+                    <th class="px-3 py-2 text-left text-xs uppercase tracking-wider text-js-text-muted">
+                      Seq
+                    </th>
+                    <th class="px-3 py-2 text-left text-xs uppercase tracking-wider text-js-text-muted">
+                      Type
+                    </th>
+                    <th class="px-3 py-2 text-left text-xs uppercase tracking-wider text-js-text-muted">
+                      At
+                    </th>
+                    <th class="px-3 py-2 text-left text-xs uppercase tracking-wider text-js-text-muted">
+                      Payload
+                    </th>
+                    <th class="px-3 py-2 text-left text-xs uppercase tracking-wider text-js-text-muted">
+                      Refs
+                    </th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-js-border">
+                  <tr :for={entry <- @entries} class="hover:bg-js-bg-elevated/50">
+                    <td class="px-3 py-2 text-xs text-js-text-subtle font-mono">{entry.seq}</td>
+                    <td class="px-3 py-2 text-xs text-js-text-subtle font-mono">{entry.kind}</td>
+                    <td class="px-3 py-2 text-xs text-js-text-subtle font-mono">
+                      {format_timestamp(entry.at)}
+                    </td>
+                    <td class="px-3 py-2 text-xs text-js-text-muted">
+                      <div class="font-mono truncate max-w-md">{entry.payload_preview}</div>
+                    </td>
+                    <td class="px-3 py-2 text-xs text-js-text-muted">
+                      <div class="flex items-center gap-2 flex-wrap">
+                        <.link
+                          :if={entry.trace_id}
+                          navigate={trace_path(@prefix, entry.trace_id)}
+                          class="text-js-info hover:text-js-text"
+                        >
+                          trace:{entry.trace_id}
+                        </.link>
+                        <span :if={entry.span_id} class="font-mono text-js-text-subtle">
+                          span:{entry.span_id}
+                        </span>
+                        <span :if={entry.trace_id == nil and entry.span_id == nil}>—</span>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </.card>
+        </div>
+      <% end %>
+    </div>
+    """
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div class="p-6 space-y-6">
+      <.page_header
+        title="Threads"
+        subtitle="Browse thread and memory checkpoints from Studio persistence"
+      >
+        <:actions>
+          <form phx-change="search" class="flex items-center gap-2">
+            <input
+              type="text"
+              name="q"
+              value={@query}
+              placeholder="Search thread/agent/instance"
+              class="w-64 rounded-md border border-js-border bg-js-bg-elevated px-3 py-1.5 text-xs text-js-text focus:outline-none focus:ring-2 focus:ring-js-ring"
+            />
+          </form>
+        </:actions>
+      </.page_header>
+
+      <.card :if={@threads == []}>
+        <.empty_state
+          title="No persisted threads"
+          description="Thread checkpoints appear after interacting with agent chat and persistence is enabled."
+        />
+      </.card>
+
+      <.card :if={@threads != []} class="p-0 overflow-hidden">
+        <div class="overflow-x-auto">
+          <table class="w-full">
+            <thead>
+              <tr class="border-b border-js-border">
+                <th class="px-3 py-2 text-left text-xs uppercase tracking-wider text-js-text-muted">
+                  Thread ID
+                </th>
+                <th class="px-3 py-2 text-left text-xs uppercase tracking-wider text-js-text-muted">
+                  Agent
+                </th>
+                <th class="px-3 py-2 text-left text-xs uppercase tracking-wider text-js-text-muted">
+                  Instance
+                </th>
+                <th class="px-3 py-2 text-left text-xs uppercase tracking-wider text-js-text-muted">
+                  Last Updated
+                </th>
+                <th class="px-3 py-2 text-left text-xs uppercase tracking-wider text-js-text-muted">
+                  Entry Count
+                </th>
+                <th class="px-3 py-2 text-left text-xs uppercase tracking-wider text-js-text-muted">
+                </th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-js-border">
+              <tr :for={thread <- @threads} class="hover:bg-js-bg-elevated/50">
+                <td class="px-3 py-2 text-xs text-js-text-subtle font-mono">{thread.thread_id}</td>
+                <td class="px-3 py-2 text-xs text-js-text-muted">{thread.agent_slug}</td>
+                <td class="px-3 py-2 text-xs text-js-text-subtle font-mono">{thread.agent_id}</td>
+                <td class="px-3 py-2 text-xs text-js-text-subtle font-mono">
+                  {format_timestamp(thread.updated_at)}
+                </td>
+                <td class="px-3 py-2 text-xs text-js-text-subtle">{thread.entry_count}</td>
+                <td class="px-3 py-2 text-right">
+                  <.link
+                    navigate={detail_path(@prefix, thread, @query)}
+                    class="text-xs text-js-info hover:text-js-text"
+                  >
+                    View
+                  </.link>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </.card>
+    </div>
+    """
+  end
+
+  defp list_path(prefix, ""), do: prefix <> "/threads"
+  defp list_path(prefix, query), do: prefix <> "/threads?" <> URI.encode_query(%{"q" => query})
+
+  defp detail_path(prefix, thread, query) do
+    base =
+      prefix <>
+        "/threads/" <>
+        URI.encode_www_form(thread.agent_slug) <>
+        "/" <>
+        URI.encode_www_form(thread.instance_id) <>
+        "/" <>
+        URI.encode_www_form(thread.thread_id)
+
+    if query == "" do
+      base
+    else
+      base <> "?" <> URI.encode_query(%{"q" => query})
+    end
+  end
+
+  defp query_path(prefix, query, :show, thread) when is_map(thread) do
+    detail_path(prefix, thread, query)
+  end
+
+  defp query_path(prefix, query, _action, _thread), do: list_path(prefix, query)
+
+  defp trace_path(prefix, trace_id), do: prefix <> "/traces/" <> URI.encode_www_form(trace_id)
+
+  defp decode_segment(value) when is_binary(value), do: URI.decode_www_form(value)
+  defp decode_segment(_), do: ""
+
+  defp format_timestamp(ts) when is_integer(ts) and ts > 0 do
+    ts
+    |> DateTime.from_unix!(:millisecond)
+    |> Calendar.strftime("%Y-%m-%d %H:%M:%S")
+  end
+
+  defp format_timestamp(_), do: "—"
+
+  defp normalize_optional_string(value) when is_binary(value) and value != "", do: value
+  defp normalize_optional_string(_), do: nil
+end

--- a/lib/jido_studio/live/traces_live.ex
+++ b/lib/jido_studio/live/traces_live.ex
@@ -4,31 +4,24 @@ defmodule JidoStudio.TracesLive do
 
   import JidoStudio.Components
 
-  alias JidoStudio.Observability
+  alias JidoStudio.Tracing
+
+  @default_range "1h"
+  @default_limit 400
 
   @impl true
   def mount(_params, _session, socket) do
-    if connected?(socket), do: :timer.send_interval(2000, self(), :refresh)
+    if connected?(socket), do: :timer.send_interval(2_000, self(), :refresh)
 
     socket =
       socket
       |> assign(:page_title, "Traces")
+      |> assign(:filters, default_filters())
+      |> assign(:traces, [])
+      |> assign(:trace, nil)
+      |> assign(:spans, [])
       |> assign(:events, [])
-      |> assign(:trace_groups, [])
-      |> assign(:filters_active?, false)
-      |> assign(:source_filter, nil)
-      |> assign(:agent_slug_filter, nil)
-      |> assign(:agent_module_filter, nil)
-      |> assign(:agent_id_filter, nil)
-      |> assign(:instance_id_filter, nil)
-      |> assign(:trace_id_filter, nil)
-      |> assign(:span_id_filter, nil)
-      |> assign(:parent_span_id_filter, nil)
-      |> assign(:causation_id_filter, nil)
-      |> assign(:call_id_filter, nil)
-      |> assign(:signal_type_filter, nil)
-      |> assign(:directive_type_filter, nil)
-      |> assign(:trace_page_limit, Observability.trace_page_limit())
+      |> assign(:available_agents, [])
 
     {:ok, socket}
   end
@@ -37,334 +30,381 @@ defmodule JidoStudio.TracesLive do
   def handle_params(params, _uri, socket) do
     filters = parse_filters(params)
 
-    events =
-      load_events(socket.assigns.jido_instance,
-        filters: filters,
-        limit: socket.assigns.trace_page_limit
-      )
+    traces = Tracing.list_traces(filters: filters, limit: @default_limit)
+
+    available_agents =
+      traces
+      |> Enum.map(& &1[:agent_id])
+      |> Enum.filter(&is_binary/1)
+      |> Enum.uniq()
+      |> Enum.sort()
+
+    socket =
+      socket
+      |> assign(:filters, filters)
+      |> assign(:traces, traces)
+      |> assign(:available_agents, available_agents)
+
+    case socket.assigns.live_action do
+      :show ->
+        trace_id = decode_segment(params["trace_id"])
+
+        case Tracing.get_trace(trace_id) do
+          {:ok, trace} ->
+            spans = Tracing.list_trace_spans(trace_id, limit: 5_000)
+            events = Tracing.list_trace_events(trace_id, order: :asc, limit: 1_500)
+
+            {:noreply,
+             socket
+             |> assign(:trace, trace)
+             |> assign(:spans, spans)
+             |> assign(:events, events)}
+
+          _ ->
+            {:noreply,
+             socket
+             |> put_flash(:error, "Trace not found")
+             |> assign(:trace, nil)
+             |> assign(:spans, [])
+             |> assign(:events, [])}
+        end
+
+      _ ->
+        {:noreply,
+         socket
+         |> assign(:trace, nil)
+         |> assign(:spans, [])
+         |> assign(:events, [])}
+    end
+  end
+
+  @impl true
+  def handle_event("filters_change", %{"filters" => params}, socket) do
+    filters =
+      socket.assigns.filters
+      |> Map.merge(normalize_filter_params(params))
+      |> Map.update(:range, @default_range, fn value -> value || @default_range end)
 
     {:noreply,
-     socket
-     |> assign(:source_filter, filters[:source])
-     |> assign(:agent_slug_filter, filters[:agent_slug])
-     |> assign(:agent_module_filter, filters[:agent_module])
-     |> assign(:agent_id_filter, filters[:agent_id])
-     |> assign(:instance_id_filter, filters[:instance_id])
-     |> assign(:trace_id_filter, filters[:trace_id])
-     |> assign(:span_id_filter, filters[:span_id])
-     |> assign(:parent_span_id_filter, filters[:parent_span_id])
-     |> assign(:causation_id_filter, filters[:causation_id])
-     |> assign(:call_id_filter, filters[:call_id])
-     |> assign(:signal_type_filter, filters[:signal_type])
-     |> assign(:directive_type_filter, filters[:directive_type])
-     |> assign(:filters_active?, filters_active?(filters))
-     |> assign(:events, events)
-     |> assign(:trace_groups, trace_groups(events))}
+     push_patch(socket,
+       to: list_path(socket.assigns.prefix, filters)
+     )}
   end
 
   @impl true
   def handle_info(:refresh, socket) do
-    filters = current_filters(socket)
+    filters = socket.assigns.filters
 
-    events =
-      load_events(socket.assigns.jido_instance,
-        filters: filters,
-        limit: socket.assigns.trace_page_limit
+    traces = Tracing.list_traces(filters: filters, limit: @default_limit)
+
+    socket =
+      socket
+      |> assign(:traces, traces)
+      |> assign(
+        :available_agents,
+        traces
+        |> Enum.map(& &1[:agent_id])
+        |> Enum.filter(&is_binary/1)
+        |> Enum.uniq()
+        |> Enum.sort()
       )
 
-    {:noreply,
-     socket
-     |> assign(:events, events)
-     |> assign(:trace_groups, trace_groups(events))}
-  end
+    socket =
+      if socket.assigns.live_action == :show and socket.assigns.trace do
+        trace_id = socket.assigns.trace[:trace_id] || socket.assigns.trace[:id]
 
-  defp load_events(jido_instance, opts) do
-    filters = Keyword.get(opts, :filters, %{})
-    limit = Keyword.get(opts, :limit, Observability.trace_page_limit())
+        trace =
+          case Tracing.get_trace(trace_id) do
+            {:ok, t} -> t
+            _ -> socket.assigns.trace
+          end
 
-    Observability.query_events(jido_instance, filters: filters, limit: limit)
-    |> Enum.filter(&matches_agent_filter?(&1, filters))
-  rescue
-    _ -> []
-  end
-
-  defp matches_agent_filter?(_event, %{agent_slug: nil, agent_module: nil}), do: true
-
-  defp matches_agent_filter?(event, filters) do
-    slug = filters[:agent_slug]
-    module = filters[:agent_module]
-
-    candidate_values = event_candidate_values(event)
-
-    matches_slug? =
-      case slug do
-        nil -> true
-        _ -> slug in candidate_values
+        socket
+        |> assign(:trace, trace)
+        |> assign(:spans, Tracing.list_trace_spans(trace_id, limit: 5_000))
+        |> assign(:events, Tracing.list_trace_events(trace_id, order: :asc, limit: 1_500))
+      else
+        socket
       end
 
-    matches_module? =
-      case module do
-        nil -> true
-        _ -> module in candidate_values
-      end
-
-    matches_slug? and matches_module?
-  end
-
-  defp event_candidate_values(event) do
-    metadata = event[:metadata] || %{}
-
-    metadata
-    |> Map.values()
-    |> Enum.flat_map(&metadata_value_candidates/1)
-    |> Enum.uniq()
-  end
-
-  defp metadata_value_candidates(%{__struct__: mod} = struct) when is_atom(mod) do
-    [inspect(mod), module_slug(mod), inspect(struct)]
-  end
-
-  defp metadata_value_candidates(mod) when is_atom(mod), do: [inspect(mod), module_slug(mod)]
-  defp metadata_value_candidates(value) when is_binary(value), do: [value]
-  defp metadata_value_candidates(value) when is_integer(value), do: [Integer.to_string(value)]
-  defp metadata_value_candidates(_), do: []
-
-  defp module_slug(module) do
-    module
-    |> Atom.to_string()
-    |> then(&:crypto.hash(:sha256, &1))
-    |> Base.url_encode64(padding: false)
-    |> binary_part(0, 8)
-  end
-
-  defp trace_groups(events) do
-    events
-    |> Enum.filter(&(is_binary(&1[:trace_id]) and &1[:trace_id] != ""))
-    |> Enum.group_by(& &1.trace_id)
-    |> Enum.map(fn {trace_id, trace_events} ->
-      sorted = Enum.sort_by(trace_events, &(&1[:timestamp_ms] || 0), :asc)
-      first = List.first(sorted)
-      last = List.last(sorted)
-
-      %{
-        trace_id: trace_id,
-        events: length(sorted),
-        start_at: first && first[:timestamp_ms],
-        end_at: last && last[:timestamp_ms],
-        duration_ms:
-          max(((last && last[:timestamp_ms]) || 0) - ((first && first[:timestamp_ms]) || 0), 0),
-        start_count: Enum.count(sorted, &(&1[:type] == :start)),
-        stop_count: Enum.count(sorted, &(&1[:type] == :stop)),
-        exception_count: Enum.count(sorted, &(&1[:type] == :exception))
-      }
-    end)
-    |> Enum.sort_by(& &1.start_at, :desc)
-  end
-
-  defp format_event_name(event_prefix) when is_list(event_prefix),
-    do: Enum.join(event_prefix, ".")
-
-  defp format_event_name(value) when is_binary(value), do: value
-  defp format_event_name(value), do: inspect(value)
-
-  defp format_timestamp(ts) when is_integer(ts) do
-    ts
-    |> DateTime.from_unix!(:millisecond)
-    |> Calendar.strftime("%H:%M:%S.%f")
-    |> String.slice(0, 12)
-  end
-
-  defp format_timestamp(_), do: "—"
-
-  defp event_badge_variant(:exception), do: :error
-  defp event_badge_variant(:stop), do: :success
-  defp event_badge_variant(:start), do: :info
-  defp event_badge_variant(_), do: :default
-
-  defp source_badge_variant(:telemetry), do: :info
-  defp source_badge_variant(:agent_debug), do: :warning
-  defp source_badge_variant(_), do: :default
-
-  defp blank_to_nil(nil), do: nil
-  defp blank_to_nil(""), do: nil
-  defp blank_to_nil(value), do: value
-
-  defp parse_filters(params) do
-    %{
-      source: parse_source(blank_to_nil(params["source"])),
-      agent_slug: blank_to_nil(params["agent_slug"]),
-      agent_module: blank_to_nil(params["agent_module"]),
-      agent_id: blank_to_nil(params["agent_id"]),
-      instance_id: blank_to_nil(params["instance_id"]),
-      trace_id: blank_to_nil(params["trace_id"]),
-      span_id: blank_to_nil(params["span_id"]),
-      parent_span_id: blank_to_nil(params["parent_span_id"]),
-      causation_id: blank_to_nil(params["causation_id"]),
-      call_id: blank_to_nil(params["call_id"]),
-      signal_type: blank_to_nil(params["signal_type"]),
-      directive_type: blank_to_nil(params["directive_type"])
-    }
-  end
-
-  defp parse_source(nil), do: nil
-  defp parse_source("telemetry"), do: :telemetry
-  defp parse_source("agent_debug"), do: :agent_debug
-  defp parse_source(_), do: nil
-
-  defp current_filters(socket) do
-    %{
-      source: socket.assigns.source_filter,
-      agent_slug: socket.assigns.agent_slug_filter,
-      agent_module: socket.assigns.agent_module_filter,
-      agent_id: socket.assigns.agent_id_filter,
-      instance_id: socket.assigns.instance_id_filter,
-      trace_id: socket.assigns.trace_id_filter,
-      span_id: socket.assigns.span_id_filter,
-      parent_span_id: socket.assigns.parent_span_id_filter,
-      causation_id: socket.assigns.causation_id_filter,
-      call_id: socket.assigns.call_id_filter,
-      signal_type: socket.assigns.signal_type_filter,
-      directive_type: socket.assigns.directive_type_filter
-    }
-  end
-
-  defp filters_active?(filters) when is_map(filters) do
-    Enum.any?(filters, fn {_k, v} -> not is_nil(v) and v != "" end)
+    {:noreply, socket}
   end
 
   @impl true
-  def render(assigns) do
+  def render(%{live_action: :show} = assigns) do
     ~H"""
     <div class="p-6 space-y-6">
-      <.page_header title="Traces" subtitle="Telemetry + debug events with correlation context">
+      <.page_header title="Trace Detail" subtitle="Span timeline, metadata, and correlation context">
         <:actions>
           <.link
-            :if={@filters_active?}
-            navigate={@prefix <> "/traces"}
+            navigate={list_path(@prefix, @filters)}
             class="inline-flex items-center gap-2 rounded-md border border-js-border px-3 py-1.5 text-xs text-js-text-muted hover:text-js-text hover:bg-js-bg-elevated transition-colors"
           >
-            Clear Filter
+            Back to Traces
           </.link>
-          <.badge>showing {length(@events)} / {@trace_page_limit}</.badge>
         </:actions>
       </.page_header>
 
-      <div
-        :if={@filters_active?}
-        class="bg-js-info/15 border border-js-border rounded-lg p-3 text-xs text-js-text-muted flex flex-wrap gap-2"
-      >
-        <span :if={@source_filter}>
-          source=<code class="bg-js-bg-elevated px-1 rounded">{@source_filter}</code>
-        </span>
-        <span :if={@agent_slug_filter}>
-          slug=<code class="bg-js-bg-elevated px-1 rounded">{@agent_slug_filter}</code>
-        </span>
-        <span :if={@agent_module_filter}>
-          module=<code class="bg-js-bg-elevated px-1 rounded">{@agent_module_filter}</code>
-        </span>
-        <span :if={@agent_id_filter}>
-          agent=<code class="bg-js-bg-elevated px-1 rounded">{@agent_id_filter}</code>
-        </span>
-        <span :if={@trace_id_filter}>
-          trace=<code class="bg-js-bg-elevated px-1 rounded">{@trace_id_filter}</code>
-        </span>
-        <span :if={@span_id_filter}>
-          span=<code class="bg-js-bg-elevated px-1 rounded">{@span_id_filter}</code>
-        </span>
-        <span :if={@causation_id_filter}>
-          cause=<code class="bg-js-bg-elevated px-1 rounded">{@causation_id_filter}</code>
-        </span>
-        <span :if={@call_id_filter}>
-          call=<code class="bg-js-bg-elevated px-1 rounded">{@call_id_filter}</code>
-        </span>
-      </div>
+      <.card :if={is_nil(@trace)}>
+        <.empty_state title="Trace not found" description="The selected trace is not available." />
+      </.card>
 
-      <.card :if={@events == []}>
+      <%= if @trace do %>
+        <div class="grid grid-cols-1 lg:grid-cols-4 gap-4">
+          <.card class="lg:col-span-1">
+            <div class="space-y-2 text-xs text-js-text-muted">
+              <div>
+                <span class="text-js-text-subtle">Trace ID:</span>
+                <code>{@trace.trace_id || @trace.id}</code>
+              </div>
+              <div><span class="text-js-text-subtle">Agent:</span> {@trace.agent_id || "—"}</div>
+              <div><span class="text-js-text-subtle">Status:</span> {trace_status(@trace)}</div>
+              <div>
+                <span class="text-js-text-subtle">Started:</span> {format_datetime(@trace.started_at)}
+              </div>
+              <div>
+                <span class="text-js-text-subtle">Ended:</span> {format_datetime(@trace.ended_at)}
+              </div>
+              <div>
+                <span class="text-js-text-subtle">Duration:</span> {format_duration(
+                  @trace.duration_ms
+                )}
+              </div>
+              <div>
+                <span class="text-js-text-subtle">Call ID:</span>
+                <code>{@trace.call_id || "—"}</code>
+              </div>
+              <div>
+                <span class="text-js-text-subtle">Causation ID:</span>
+                <code>{@trace.causation_id || "—"}</code>
+              </div>
+              <div>
+                <span class="text-js-text-subtle">Spans:</span> {@trace.span_count || length(@spans)}
+              </div>
+              <div>
+                <span class="text-js-text-subtle">Events:</span> {@trace.event_count ||
+                  length(@events)}
+              </div>
+            </div>
+          </.card>
+
+          <.card class="lg:col-span-3 p-0 overflow-hidden">
+            <div class="px-3 py-2 border-b border-js-border">
+              <h3 class="text-sm font-medium text-js-text">Timeline</h3>
+              <p class="text-xs text-js-text-muted mt-1">Span hierarchy ordered by start time.</p>
+            </div>
+
+            <div :if={@spans == []} class="p-4">
+              <.empty_state
+                title="No spans"
+                description="No span records were stored for this trace yet."
+              />
+            </div>
+
+            <div :if={@spans != []} class="overflow-x-auto">
+              <table class="w-full">
+                <thead>
+                  <tr class="border-b border-js-border">
+                    <th class="px-3 py-2 text-left text-xs uppercase tracking-wider text-js-text-muted">
+                      Span
+                    </th>
+                    <th class="px-3 py-2 text-left text-xs uppercase tracking-wider text-js-text-muted">
+                      Status
+                    </th>
+                    <th class="px-3 py-2 text-left text-xs uppercase tracking-wider text-js-text-muted">
+                      Offset
+                    </th>
+                    <th class="px-3 py-2 text-left text-xs uppercase tracking-wider text-js-text-muted">
+                      Duration
+                    </th>
+                    <th class="px-3 py-2 text-left text-xs uppercase tracking-wider text-js-text-muted">
+                      Span ID
+                    </th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-js-border">
+                  <tr :for={span <- @spans} class="hover:bg-js-bg-elevated/40">
+                    <td class="px-3 py-2 text-xs text-js-text-muted font-mono">
+                      <span style={"padding-left: #{(span.depth || 0) * 16}px"}>
+                        {span.event_name}
+                      </span>
+                    </td>
+                    <td class="px-3 py-2 text-xs">
+                      <.badge variant={span_badge_variant(span.status)}>
+                        {span.status || "running"}
+                      </.badge>
+                    </td>
+                    <td class="px-3 py-2 text-xs text-js-text-subtle font-mono">
+                      {format_duration(span.offset_ms)}
+                    </td>
+                    <td class="px-3 py-2 text-xs text-js-text-subtle font-mono">
+                      {format_duration(span.duration_ms)}
+                    </td>
+                    <td class="px-3 py-2 text-xs text-js-text-subtle font-mono">{span.span_id}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </.card>
+        </div>
+
+        <.card :if={@trace.error}>
+          <h3 class="text-sm font-medium text-js-error mb-2">Error Payload</h3>
+          <pre class="text-xs text-js-text-muted bg-js-bg-elevated border border-js-border rounded-md p-3 whitespace-pre-wrap break-words"><%= inspect(@trace.error_payload || %{}, pretty: true, limit: 80, printable_limit: 20_000) %></pre>
+        </.card>
+
+        <.card>
+          <h3 class="text-sm font-medium text-js-text mb-2">Trace Events</h3>
+          <div :if={@events == []} class="text-xs text-js-text-subtle">No events captured.</div>
+          <div :if={@events != []} class="space-y-2 max-h-[24rem] overflow-y-auto js-scroll">
+            <div
+              :for={event <- @events}
+              class="rounded-md border border-js-border bg-js-bg-elevated/40 px-2.5 py-2"
+            >
+              <div class="flex items-center justify-between gap-2">
+                <span class="text-[11px] font-mono text-js-text-subtle">
+                  {format_timestamp(event.timestamp_ms)}
+                </span>
+                <.badge variant={event_badge_variant(event.type)}>{event.type || :event}</.badge>
+              </div>
+              <div class="mt-1 text-xs text-js-text font-mono">{event_name(event)}</div>
+            </div>
+          </div>
+        </.card>
+      <% end %>
+    </div>
+    """
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div class="p-6 space-y-6">
+      <.page_header title="Traces" subtitle="Explore trace runs and execution timelines">
+        <:actions>
+          <.badge>showing {length(@traces)} traces</.badge>
+        </:actions>
+      </.page_header>
+
+      <.card>
+        <form phx-change="filters_change" class="grid grid-cols-1 md:grid-cols-5 gap-2">
+          <label class="text-xs text-js-text-muted">
+            Agent
+            <select
+              name="filters[agent]"
+              class="mt-1 w-full rounded-md border border-js-border bg-js-bg-elevated px-2 py-1.5 text-xs text-js-text"
+            >
+              <option value="">All</option>
+              <option
+                :for={agent <- @available_agents}
+                value={agent}
+                selected={agent == @filters.agent}
+              >
+                {agent}
+              </option>
+            </select>
+          </label>
+
+          <label class="text-xs text-js-text-muted">
+            Status
+            <select
+              name="filters[status]"
+              class="mt-1 w-full rounded-md border border-js-border bg-js-bg-elevated px-2 py-1.5 text-xs text-js-text"
+            >
+              <option value="all" selected={@filters.status == "all"}>All</option>
+              <option value="running" selected={@filters.status == "running"}>Running</option>
+              <option value="ok" selected={@filters.status == "ok"}>OK</option>
+              <option value="error" selected={@filters.status == "error"}>Error</option>
+            </select>
+          </label>
+
+          <label class="text-xs text-js-text-muted">
+            Time Range
+            <select
+              name="filters[range]"
+              class="mt-1 w-full rounded-md border border-js-border bg-js-bg-elevated px-2 py-1.5 text-xs text-js-text"
+            >
+              <option value="15m" selected={@filters.range == "15m"}>15m</option>
+              <option value="1h" selected={@filters.range == "1h"}>1h</option>
+              <option value="24h" selected={@filters.range == "24h"}>24h</option>
+              <option value="custom" selected={@filters.range == "custom"}>Custom</option>
+            </select>
+          </label>
+
+          <label class="text-xs text-js-text-muted">
+            From
+            <input
+              type="datetime-local"
+              name="filters[from]"
+              value={@filters.from || ""}
+              class="mt-1 w-full rounded-md border border-js-border bg-js-bg-elevated px-2 py-1.5 text-xs text-js-text"
+            />
+          </label>
+
+          <label class="text-xs text-js-text-muted">
+            To
+            <input
+              type="datetime-local"
+              name="filters[to]"
+              value={@filters.to || ""}
+              class="mt-1 w-full rounded-md border border-js-border bg-js-bg-elevated px-2 py-1.5 text-xs text-js-text"
+            />
+          </label>
+        </form>
+      </.card>
+
+      <.card :if={@traces == []}>
         <.empty_state
-          title="No trace events yet"
-          description="Trace/debug events will appear here as agents execute. If filtering is active, try clearing the filter."
+          title="No traces"
+          description="No trace runs matched the current filters."
         />
       </.card>
 
-      <.card :if={@trace_groups != []}>
-        <h3 class="text-sm font-medium text-js-text mb-3">Trace Timeline</h3>
-        <div class="space-y-2">
-          <div
-            :for={group <- Enum.take(@trace_groups, 8)}
-            class="rounded-md border border-js-border bg-js-bg-elevated/30 px-3 py-2 text-xs"
-          >
-            <div class="flex items-center justify-between gap-2">
-              <code class="text-js-text">{group.trace_id}</code>
-              <span class="text-js-text-subtle">{group.events} events</span>
-            </div>
-            <div class="mt-1 text-js-text-muted flex flex-wrap gap-x-3 gap-y-1">
-              <span>duration: {group.duration_ms}ms</span>
-              <span>start: {group.start_count}</span>
-              <span>stop: {group.stop_count}</span>
-              <span>exception: {group.exception_count}</span>
-            </div>
-          </div>
-        </div>
-      </.card>
-
-      <.card :if={@events != []} class="p-0">
+      <.card :if={@traces != []} class="p-0 overflow-hidden">
         <div class="overflow-x-auto">
           <table class="w-full">
             <thead>
               <tr class="border-b border-js-border">
-                <th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-js-text-muted">
-                  Time
+                <th class="px-3 py-2 text-left text-xs uppercase tracking-wider text-js-text-muted">
+                  Trace ID
                 </th>
-                <th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-js-text-muted">
-                  Source
-                </th>
-                <th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-js-text-muted">
-                  Event
-                </th>
-                <th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-js-text-muted">
-                  Type
-                </th>
-                <th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-js-text-muted">
+                <th class="px-3 py-2 text-left text-xs uppercase tracking-wider text-js-text-muted">
                   Agent
                 </th>
-                <th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-js-text-muted">
-                  Trace
+                <th class="px-3 py-2 text-left text-xs uppercase tracking-wider text-js-text-muted">
+                  Status
                 </th>
-                <th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-js-text-muted">
-                  Call
+                <th class="px-3 py-2 text-left text-xs uppercase tracking-wider text-js-text-muted">
+                  Started
                 </th>
-                <th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-js-text-muted">
-                  Details
+                <th class="px-3 py-2 text-left text-xs uppercase tracking-wider text-js-text-muted">
+                  Duration
+                </th>
+                <th class="px-3 py-2 text-left text-xs uppercase tracking-wider text-js-text-muted">
+                  Error?
                 </th>
               </tr>
             </thead>
             <tbody class="divide-y divide-js-border">
-              <tr :for={event <- @events} class="hover:bg-js-bg-elevated transition-colors">
-                <td class="px-3 py-2 text-xs text-js-text-subtle font-mono whitespace-nowrap">
-                  {format_timestamp(event[:timestamp_ms])}
+              <tr :for={trace <- @traces} class="hover:bg-js-bg-elevated/50">
+                <td class="px-3 py-2 text-xs text-js-info font-mono">
+                  <.link navigate={detail_path(@prefix, trace.trace_id || trace.id, @filters)}>
+                    {trace.trace_id || trace.id}
+                  </.link>
                 </td>
+                <td class="px-3 py-2 text-xs text-js-text-muted">{trace.agent_id || "—"}</td>
                 <td class="px-3 py-2 text-xs">
-                  <.badge variant={source_badge_variant(event[:source])}>{event[:source]}</.badge>
-                </td>
-                <td class="px-3 py-2 text-xs text-js-text-muted font-mono">
-                  {format_event_name(event[:event_prefix] || event[:event_name])}
-                </td>
-                <td class="px-3 py-2 text-xs">
-                  <.badge variant={event_badge_variant(event[:type])}>
-                    {to_string(event[:type] || "event")}
+                  <.badge variant={span_badge_variant(trace.status)}>
+                    {trace.status || "running"}
                   </.badge>
                 </td>
                 <td class="px-3 py-2 text-xs text-js-text-subtle font-mono">
-                  {event[:agent_id] || "—"}
+                  {format_datetime(trace.started_at)}
                 </td>
                 <td class="px-3 py-2 text-xs text-js-text-subtle font-mono">
-                  {event[:trace_id] || "—"}
+                  {format_duration(trace.duration_ms)}
                 </td>
-                <td class="px-3 py-2 text-xs text-js-text-subtle font-mono">
-                  {event[:call_id] || "—"}
-                </td>
-                <td class="px-3 py-2 text-xs text-js-text-subtle font-mono max-w-xs truncate">
-                  {inspect(event[:metadata] || %{}, limit: 4)}
+                <td class="px-3 py-2 text-xs text-js-text-subtle">
+                  {if(trace.error, do: "yes", else: "no")}
                 </td>
               </tr>
             </tbody>
@@ -374,4 +414,146 @@ defmodule JidoStudio.TracesLive do
     </div>
     """
   end
+
+  defp default_filters do
+    %{agent: nil, status: "all", range: @default_range, from: nil, to: nil}
+  end
+
+  defp parse_filters(params) when is_map(params) do
+    from_params = normalize_filter_params(params)
+
+    default_filters()
+    |> Map.merge(from_params)
+    |> Map.put(:range, normalize_range(from_params[:range] || @default_range))
+    |> maybe_clear_custom_bounds()
+  end
+
+  defp parse_filters(_), do: default_filters()
+
+  defp normalize_filter_params(params) do
+    source = params["filters"] || params
+
+    %{
+      agent: normalize_optional_string(source["agent"]),
+      status: normalize_status(source["status"]),
+      range: normalize_range(source["range"]),
+      from: normalize_optional_string(source["from"]),
+      to: normalize_optional_string(source["to"])
+    }
+  end
+
+  defp maybe_clear_custom_bounds(%{range: "custom"} = filters), do: filters
+  defp maybe_clear_custom_bounds(filters), do: %{filters | from: nil, to: nil}
+
+  defp normalize_status(nil), do: "all"
+
+  defp normalize_status(value) when is_binary(value) do
+    normalized = String.downcase(String.trim(value))
+    if normalized in ["all", "running", "ok", "error"], do: normalized, else: "all"
+  end
+
+  defp normalize_status(_), do: "all"
+
+  defp normalize_range(nil), do: @default_range
+
+  defp normalize_range(value) when is_binary(value) do
+    normalized = String.downcase(String.trim(value))
+    if normalized in ["15m", "1h", "24h", "custom"], do: normalized, else: @default_range
+  end
+
+  defp normalize_range(_), do: @default_range
+
+  defp list_path(prefix, filters) do
+    params = filter_query_params(filters)
+
+    if map_size(params) == 0 do
+      prefix <> "/traces"
+    else
+      prefix <> "/traces?" <> URI.encode_query(params)
+    end
+  end
+
+  defp detail_path(prefix, trace_id, filters) do
+    base = prefix <> "/traces/" <> URI.encode_www_form(to_string(trace_id))
+    params = filter_query_params(filters)
+
+    if map_size(params) == 0 do
+      base
+    else
+      base <> "?" <> URI.encode_query(params)
+    end
+  end
+
+  defp filter_query_params(filters) do
+    %{}
+    |> maybe_put("agent", filters.agent)
+    |> maybe_put("status", if(filters.status == "all", do: nil, else: filters.status))
+    |> maybe_put("range", if(filters.range == @default_range, do: nil, else: filters.range))
+    |> maybe_put("from", if(filters.range == "custom", do: filters.from, else: nil))
+    |> maybe_put("to", if(filters.range == "custom", do: filters.to, else: nil))
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp decode_segment(value) when is_binary(value), do: URI.decode_www_form(value)
+  defp decode_segment(_), do: ""
+
+  defp event_name(event) when is_map(event) do
+    cond do
+      is_binary(event[:event_name]) -> event[:event_name]
+      is_list(event[:event_prefix]) -> Enum.join(event[:event_prefix], ".")
+      true -> "event"
+    end
+  end
+
+  defp event_name(_), do: "event"
+
+  defp event_badge_variant(:exception), do: :error
+  defp event_badge_variant(:stop), do: :success
+  defp event_badge_variant(:start), do: :info
+  defp event_badge_variant("exception"), do: :error
+  defp event_badge_variant("stop"), do: :success
+  defp event_badge_variant("start"), do: :info
+  defp event_badge_variant(_), do: :default
+
+  defp span_badge_variant("error"), do: :error
+  defp span_badge_variant("ok"), do: :success
+  defp span_badge_variant("running"), do: :info
+  defp span_badge_variant(:error), do: :error
+  defp span_badge_variant(:ok), do: :success
+  defp span_badge_variant(:running), do: :info
+  defp span_badge_variant(_), do: :default
+
+  defp trace_status(trace) when is_map(trace) do
+    trace[:status] || "running"
+  end
+
+  defp format_datetime(ts) when is_integer(ts) and ts > 0 do
+    ts
+    |> DateTime.from_unix!(:millisecond)
+    |> Calendar.strftime("%Y-%m-%d %H:%M:%S")
+  end
+
+  defp format_datetime(_), do: "—"
+
+  defp format_timestamp(ts) when is_integer(ts) and ts > 0 do
+    ts
+    |> DateTime.from_unix!(:millisecond)
+    |> Calendar.strftime("%H:%M:%S.%f")
+    |> String.slice(0, 12)
+  end
+
+  defp format_timestamp(_), do: "—"
+
+  defp format_duration(ms) when is_integer(ms) and ms >= 0, do: "#{ms}ms"
+  defp format_duration(_), do: "—"
+
+  defp normalize_optional_string(value) when is_binary(value) do
+    normalized = String.trim(value)
+    if normalized == "", do: nil, else: normalized
+  end
+
+  defp normalize_optional_string(value) when is_atom(value), do: Atom.to_string(value)
+  defp normalize_optional_string(_), do: nil
 end

--- a/lib/jido_studio/observability.ex
+++ b/lib/jido_studio/observability.ex
@@ -4,7 +4,7 @@ defmodule JidoStudio.Observability do
   alias JidoStudio.AgentRegistry
   alias JidoStudio.TraceBuffer
 
-  @default_trace_preview_limit 30
+  @default_trace_preview_limit 200
   @default_trace_page_limit 300
 
   @spec trace_preview(String.t(), pid() | nil, keyword()) :: map()

--- a/lib/jido_studio/persistence.ex
+++ b/lib/jido_studio/persistence.ex
@@ -1,0 +1,131 @@
+defmodule JidoStudio.Persistence do
+  @moduledoc false
+
+  @behaviour JidoStudio.Persistence.Adapter
+
+  @default_adapter JidoStudio.Persistence.ETS
+
+  @type namespace :: JidoStudio.Persistence.Adapter.namespace()
+  @type id :: JidoStudio.Persistence.Adapter.id()
+  @type doc :: JidoStudio.Persistence.Adapter.doc()
+  @type stream :: JidoStudio.Persistence.Adapter.stream()
+  @type event :: JidoStudio.Persistence.Adapter.event()
+
+  @spec child_specs(keyword()) :: [Supervisor.child_spec()]
+  def child_specs(opts \\ []) do
+    case resolve_adapter(opts) do
+      {:ok, {adapter, adapter_opts}} ->
+        if function_exported?(adapter, :child_spec, 1) do
+          case adapter.child_spec(adapter_opts) do
+            :ignore -> []
+            nil -> []
+            child_spec -> [child_spec]
+          end
+        else
+          []
+        end
+
+      {:error, _reason} ->
+        []
+    end
+  end
+
+  @impl true
+  def put_doc(namespace, id, doc, opts \\ []) do
+    with {:ok, {adapter, adapter_opts}} <- resolve_adapter(opts) do
+      adapter.put_doc(namespace, id, doc, adapter_opts)
+    end
+  end
+
+  @impl true
+  def get_doc(namespace, id, opts \\ []) do
+    with {:ok, {adapter, adapter_opts}} <- resolve_adapter(opts) do
+      adapter.get_doc(namespace, id, adapter_opts)
+    end
+  end
+
+  @impl true
+  def list_docs(namespace, opts \\ []) do
+    case resolve_adapter(opts) do
+      {:ok, {adapter, adapter_opts}} -> adapter.list_docs(namespace, adapter_opts)
+      {:error, _reason} -> []
+    end
+  end
+
+  @impl true
+  def delete_doc(namespace, id, opts \\ []) do
+    with {:ok, {adapter, adapter_opts}} <- resolve_adapter(opts) do
+      adapter.delete_doc(namespace, id, adapter_opts)
+    end
+  end
+
+  @impl true
+  def append_event(stream, event, opts \\ []) do
+    with {:ok, {adapter, adapter_opts}} <- resolve_adapter(opts) do
+      adapter.append_event(stream, event, adapter_opts)
+    end
+  end
+
+  @impl true
+  def read_events(stream, opts \\ []) do
+    case resolve_adapter(opts) do
+      {:ok, {adapter, adapter_opts}} -> adapter.read_events(stream, adapter_opts)
+      {:error, _reason} -> []
+    end
+  end
+
+  @spec adapter() :: module()
+  def adapter do
+    case resolve_adapter() do
+      {:ok, {adapter, _opts}} -> adapter
+      {:error, _} -> @default_adapter
+    end
+  end
+
+  @spec resolve_adapter(keyword()) :: {:ok, {module(), keyword()}} | {:error, term()}
+  def resolve_adapter(runtime_opts \\ []) do
+    config = persistence_config()
+
+    adapter =
+      runtime_opts
+      |> Keyword.get(:adapter)
+      |> case do
+        nil -> Keyword.get(config, :adapter, @default_adapter)
+        value -> value
+      end
+
+    adapter_opts =
+      config
+      |> Keyword.get(:opts, [])
+      |> Keyword.merge(Keyword.get(runtime_opts, :opts, []))
+      |> Keyword.merge(Keyword.drop(runtime_opts, [:adapter, :opts]))
+
+    _ = Code.ensure_loaded(adapter)
+
+    if valid_adapter?(adapter) do
+      {:ok, {adapter, adapter_opts}}
+    else
+      {:error, {:invalid_persistence_adapter, adapter}}
+    end
+  rescue
+    error ->
+      {:error, {:persistence_resolution_failed, Exception.message(error)}}
+  end
+
+  defp persistence_config do
+    Application.get_env(:jido_studio, :persistence, [])
+    |> Keyword.put_new(:adapter, @default_adapter)
+    |> Keyword.put_new(:opts, [])
+  end
+
+  defp valid_adapter?(adapter) when is_atom(adapter) do
+    function_exported?(adapter, :put_doc, 4) and
+      function_exported?(adapter, :get_doc, 3) and
+      function_exported?(adapter, :list_docs, 2) and
+      function_exported?(adapter, :delete_doc, 3) and
+      function_exported?(adapter, :append_event, 3) and
+      function_exported?(adapter, :read_events, 2)
+  end
+
+  defp valid_adapter?(_), do: false
+end

--- a/lib/jido_studio/persistence/adapter.ex
+++ b/lib/jido_studio/persistence/adapter.ex
@@ -1,0 +1,17 @@
+defmodule JidoStudio.Persistence.Adapter do
+  @moduledoc false
+
+  @type namespace :: atom() | String.t()
+  @type id :: String.t()
+  @type doc :: map()
+  @type stream :: String.t()
+  @type event :: map()
+
+  @callback put_doc(namespace(), id(), doc(), keyword()) :: :ok | {:error, term()}
+  @callback get_doc(namespace(), id(), keyword()) :: {:ok, doc()} | :not_found | {:error, term()}
+  @callback list_docs(namespace(), keyword()) :: [doc()]
+  @callback delete_doc(namespace(), id(), keyword()) :: :ok | {:error, term()}
+
+  @callback append_event(stream(), event(), keyword()) :: {:ok, event()} | {:error, term()}
+  @callback read_events(stream(), keyword()) :: [event()]
+end

--- a/lib/jido_studio/persistence/ecto.ex
+++ b/lib/jido_studio/persistence/ecto.ex
@@ -1,0 +1,314 @@
+defmodule JidoStudio.Persistence.Ecto do
+  @moduledoc false
+
+  @behaviour JidoStudio.Persistence.Adapter
+
+  @default_docs_table "jido_studio_docs"
+  @default_events_table "jido_studio_events"
+  @default_read_limit 200
+
+  @impl true
+  def put_doc(namespace, id, doc, opts) when is_map(doc) do
+    with {:ok, repo, query_opts, docs_table, _events_table} <- resolve(opts),
+         {:ok, json_doc} <- encode_json(doc),
+         {:ok, _result} <-
+           query(
+             repo,
+             """
+             INSERT INTO #{docs_table} (namespace, doc_id, data, inserted_at, updated_at)
+             VALUES ($1, $2, $3::jsonb, NOW(), NOW())
+             ON CONFLICT (namespace, doc_id)
+             DO UPDATE SET data = EXCLUDED.data, updated_at = NOW()
+             """,
+             [to_string(namespace), to_string(id), json_doc],
+             query_opts
+           ) do
+      :ok
+    end
+  end
+
+  def put_doc(_namespace, _id, _doc, _opts), do: {:error, :invalid_doc}
+
+  @impl true
+  def get_doc(namespace, id, opts) do
+    with {:ok, repo, query_opts, docs_table, _events_table} <- resolve(opts),
+         {:ok, result} <-
+           query(
+             repo,
+             "SELECT data FROM #{docs_table} WHERE namespace = $1 AND doc_id = $2 LIMIT 1",
+             [to_string(namespace), to_string(id)],
+             query_opts
+           ) do
+      case Map.get(result, :rows, []) do
+        [[data]] -> decode_json_result(data)
+        _ -> :not_found
+      end
+    end
+  end
+
+  @impl true
+  def list_docs(namespace, opts) do
+    with {:ok, repo, query_opts, docs_table, _events_table} <- resolve(opts),
+         {:ok, {sql, params}} <- docs_list_query(docs_table, namespace, opts),
+         {:ok, result} <- query(repo, sql, params, query_opts) do
+      rows_to_docs(result)
+    else
+      _ -> []
+    end
+  end
+
+  @impl true
+  def delete_doc(namespace, id, opts) do
+    with {:ok, repo, query_opts, docs_table, _events_table} <- resolve(opts),
+         {:ok, _result} <-
+           query(
+             repo,
+             "DELETE FROM #{docs_table} WHERE namespace = $1 AND doc_id = $2",
+             [to_string(namespace), to_string(id)],
+             query_opts
+           ) do
+      :ok
+    end
+  end
+
+  @impl true
+  def append_event(stream, event, opts) when is_binary(stream) and is_map(event) do
+    with {:ok, repo, query_opts, _docs_table, events_table} <- resolve(opts),
+         {:ok, json_event} <- encode_json(event),
+         {:ok, result} <-
+           query(
+             repo,
+             """
+             INSERT INTO #{events_table} (stream, event, inserted_at)
+             VALUES ($1, $2::jsonb, NOW())
+             RETURNING seq
+             """,
+             [stream, json_event],
+             query_opts
+           ) do
+      case Map.get(result, :rows, []) do
+        [[seq]] -> {:ok, Map.put(event, :seq, seq)}
+        _ -> {:error, :missing_sequence}
+      end
+    end
+  end
+
+  def append_event(_stream, _event, _opts), do: {:error, :invalid_event}
+
+  @impl true
+  def read_events(stream, opts) when is_binary(stream) do
+    with {:ok, repo, query_opts, _docs_table, events_table} <- resolve(opts),
+         {:ok, {sql, params}} <- events_read_query(events_table, stream, opts),
+         {:ok, result} <- query(repo, sql, params, query_opts) do
+      rows_to_events(result)
+    else
+      _ -> []
+    end
+  end
+
+  def read_events(_stream, _opts), do: []
+
+  defp resolve(opts) do
+    repo = Keyword.get(opts, :repo)
+
+    docs_table =
+      opts
+      |> Keyword.get(:docs_table, @default_docs_table)
+      |> normalize_identifier(@default_docs_table)
+
+    events_table =
+      opts
+      |> Keyword.get(:events_table, @default_events_table)
+      |> normalize_identifier(@default_events_table)
+
+    query_opts =
+      []
+      |> maybe_put_prefix(Keyword.get(opts, :prefix))
+      |> Keyword.put_new(:timeout, 15_000)
+
+    cond do
+      is_nil(repo) ->
+        {:error, :missing_repo}
+
+      not is_atom(repo) ->
+        {:error, :invalid_repo}
+
+      true ->
+        {:ok, repo, query_opts, docs_table, events_table}
+    end
+  end
+
+  defp docs_list_query(docs_table, namespace, opts) do
+    order = normalize_order(Keyword.get(opts, :order, :desc))
+
+    limit =
+      normalize_non_negative_integer(
+        Keyword.get(opts, :limit, @default_read_limit),
+        @default_read_limit
+      )
+
+    offset = normalize_non_negative_integer(Keyword.get(opts, :offset, 0), 0)
+    id_prefix = normalize_optional_string(Keyword.get(opts, :id_prefix))
+
+    {sql, params} =
+      if is_binary(id_prefix) do
+        {
+          """
+          SELECT doc_id, data
+          FROM #{docs_table}
+          WHERE namespace = $1 AND doc_id LIKE $2
+          ORDER BY updated_at #{order}
+          LIMIT $3 OFFSET $4
+          """,
+          [to_string(namespace), "#{id_prefix}%", limit, offset]
+        }
+      else
+        {
+          """
+          SELECT doc_id, data
+          FROM #{docs_table}
+          WHERE namespace = $1
+          ORDER BY updated_at #{order}
+          LIMIT $2 OFFSET $3
+          """,
+          [to_string(namespace), limit, offset]
+        }
+      end
+
+    {:ok, {sql, params}}
+  end
+
+  defp events_read_query(events_table, stream, opts) do
+    order = normalize_order(Keyword.get(opts, :order, :asc))
+
+    limit =
+      normalize_non_negative_integer(
+        Keyword.get(opts, :limit, @default_read_limit),
+        @default_read_limit
+      )
+
+    offset = normalize_non_negative_integer(Keyword.get(opts, :offset, 0), 0)
+    after_seq = normalize_optional_integer(Keyword.get(opts, :after_seq))
+    before_seq = normalize_optional_integer(Keyword.get(opts, :before_seq))
+
+    conditions =
+      []
+      |> maybe_add_condition("seq >", after_seq)
+      |> maybe_add_condition("seq <", before_seq)
+
+    base = "SELECT seq, event FROM #{events_table} WHERE stream = $1"
+
+    {where_sql, where_params} =
+      Enum.reduce(Enum.with_index(conditions, 2), {"", [stream]}, fn {{op, value}, idx},
+                                                                     {acc_sql, acc_params} ->
+        clause = " AND #{op} $#{idx}"
+        {acc_sql <> clause, acc_params ++ [value]}
+      end)
+
+    final_sql =
+      base <>
+        where_sql <>
+        " ORDER BY seq #{order} LIMIT $#{length(where_params) + 1} OFFSET $#{length(where_params) + 2}"
+
+    {:ok, {final_sql, where_params ++ [limit, offset]}}
+  end
+
+  defp maybe_add_condition(acc, _op, nil), do: acc
+  defp maybe_add_condition(acc, op, value), do: acc ++ [{op, value}]
+
+  defp query(repo, sql, params, opts) do
+    sql_module = Module.concat([Ecto, Adapters, SQL])
+
+    cond do
+      not Code.ensure_loaded?(sql_module) ->
+        {:error, :ecto_sql_not_available}
+
+      not function_exported?(sql_module, :query, 4) ->
+        {:error, :ecto_sql_not_available}
+
+      true ->
+        case apply(sql_module, :query, [repo, sql, params, opts]) do
+          {:ok, result} -> {:ok, result}
+          {:error, reason} -> {:error, reason}
+        end
+    end
+  end
+
+  defp rows_to_docs(result) do
+    result
+    |> Map.get(:rows, [])
+    |> Enum.map(fn
+      [doc_id, data] ->
+        case decode_json_result(data) do
+          {:ok, doc} -> Map.put(doc, :id, doc_id)
+          {:error, _} -> %{id: doc_id, raw: data}
+        end
+
+      _ ->
+        %{}
+    end)
+  end
+
+  defp rows_to_events(result) do
+    result
+    |> Map.get(:rows, [])
+    |> Enum.map(fn
+      [seq, data] ->
+        case decode_json_result(data) do
+          {:ok, event} -> Map.put(event, :seq, seq)
+          _ -> %{seq: seq, raw: data}
+        end
+
+      _ ->
+        %{}
+    end)
+  end
+
+  defp decode_json_result(data) when is_map(data), do: {:ok, data}
+
+  defp decode_json_result(data) when is_binary(data) do
+    case Jason.decode(data) do
+      {:ok, decoded} when is_map(decoded) -> {:ok, decoded}
+      {:ok, _decoded} -> {:error, :invalid_json}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp decode_json_result(_), do: {:error, :invalid_json}
+
+  defp encode_json(map) when is_map(map) do
+    case Jason.encode(map) do
+      {:ok, json} -> {:ok, json}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp normalize_identifier(value, fallback) when is_binary(value) do
+    if Regex.match?(~r/^[a-zA-Z_][a-zA-Z0-9_]*$/, value), do: value, else: fallback
+  end
+
+  defp normalize_identifier(_, fallback), do: fallback
+
+  defp normalize_non_negative_integer(value, _default) when is_integer(value) and value >= 0,
+    do: value
+
+  defp normalize_non_negative_integer(_value, default), do: default
+
+  defp normalize_order(:asc), do: "ASC"
+  defp normalize_order(:desc), do: "DESC"
+  defp normalize_order("asc"), do: "ASC"
+  defp normalize_order("desc"), do: "DESC"
+  defp normalize_order(_), do: "DESC"
+
+  defp normalize_optional_string(value) when is_binary(value) and value != "", do: value
+  defp normalize_optional_string(_), do: nil
+
+  defp normalize_optional_integer(value) when is_integer(value), do: value
+  defp normalize_optional_integer(_), do: nil
+
+  defp maybe_put_prefix(opts, prefix) when is_binary(prefix) and prefix != "" do
+    Keyword.put(opts, :prefix, prefix)
+  end
+
+  defp maybe_put_prefix(opts, _prefix), do: opts
+end

--- a/lib/jido_studio/persistence/ets.ex
+++ b/lib/jido_studio/persistence/ets.ex
@@ -1,0 +1,289 @@
+defmodule JidoStudio.Persistence.ETS do
+  @moduledoc false
+  use GenServer
+
+  @behaviour JidoStudio.Persistence.Adapter
+
+  @docs_table :jido_studio_persistence_docs
+  @events_table :jido_studio_persistence_events
+  @seq_table :jido_studio_persistence_event_seq
+
+  @default_event_retention 10_000
+  @default_read_limit 200
+
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]},
+      type: :worker,
+      restart: :permanent,
+      shutdown: 5_000
+    }
+  end
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(opts) do
+    ensure_tables()
+
+    retention =
+      opts
+      |> Keyword.get(
+        :event_retention,
+        Application.get_env(:jido_studio, :persistence_event_retention, @default_event_retention)
+      )
+      |> normalize_positive_integer(@default_event_retention)
+
+    seq_by_stream =
+      :ets.tab2list(@seq_table)
+      |> Map.new(fn {stream, seq} -> {stream, seq} end)
+
+    {:ok, %{event_retention: retention, seq_by_stream: seq_by_stream}}
+  end
+
+  @impl true
+  def put_doc(namespace, id, doc, _opts) when is_map(doc) do
+    with :ok <- ensure_started() do
+      ns = normalize_namespace(namespace)
+      doc_id = normalize_id(id)
+      now = now_ms()
+
+      normalized =
+        doc
+        |> Map.put(:id, doc_id)
+        |> Map.put_new(:inserted_at, now)
+        |> Map.put(:updated_at, now)
+
+      :ets.insert(@docs_table, {{ns, doc_id}, normalized})
+      :ok
+    end
+  end
+
+  def put_doc(_namespace, _id, _doc, _opts), do: {:error, :invalid_doc}
+
+  @impl true
+  def get_doc(namespace, id, _opts) do
+    with :ok <- ensure_started() do
+      ns = normalize_namespace(namespace)
+      doc_id = normalize_id(id)
+
+      case :ets.lookup(@docs_table, {ns, doc_id}) do
+        [{{^ns, ^doc_id}, doc}] -> {:ok, doc}
+        [] -> :not_found
+      end
+    end
+  end
+
+  @impl true
+  def list_docs(namespace, opts) do
+    case ensure_started() do
+      :ok ->
+        ns = normalize_namespace(namespace)
+        id_prefix = normalize_optional_string(Keyword.get(opts, :id_prefix))
+        order = normalize_order(Keyword.get(opts, :order, :desc))
+        sort_by = Keyword.get(opts, :sort_by, :updated_at)
+
+        limit =
+          normalize_non_negative_integer(
+            Keyword.get(opts, :limit, @default_read_limit),
+            @default_read_limit
+          )
+
+        offset = normalize_non_negative_integer(Keyword.get(opts, :offset, 0), 0)
+
+        @docs_table
+        |> :ets.tab2list()
+        |> Enum.reduce([], fn
+          {{^ns, doc_id}, doc}, acc ->
+            if is_nil(id_prefix) or String.starts_with?(doc_id, id_prefix) do
+              [doc | acc]
+            else
+              acc
+            end
+
+          _, acc ->
+            acc
+        end)
+        |> Enum.sort_by(&sort_value(&1, sort_by), order)
+        |> Enum.drop(offset)
+        |> maybe_take(limit)
+
+      {:error, _reason} ->
+        []
+    end
+  end
+
+  @impl true
+  def delete_doc(namespace, id, _opts) do
+    with :ok <- ensure_started() do
+      ns = normalize_namespace(namespace)
+      doc_id = normalize_id(id)
+      :ets.delete(@docs_table, {ns, doc_id})
+      :ok
+    end
+  end
+
+  @impl true
+  def append_event(stream, event, opts) when is_binary(stream) and is_map(event) do
+    with :ok <- ensure_started() do
+      timeout = normalize_positive_integer(Keyword.get(opts, :timeout, 5_000), 5_000)
+      GenServer.call(__MODULE__, {:append_event, stream, event}, timeout)
+    end
+  end
+
+  def append_event(_stream, _event, _opts), do: {:error, :invalid_event}
+
+  @impl true
+  def read_events(stream, opts) when is_binary(stream) do
+    case ensure_started() do
+      :ok ->
+        order = normalize_order(Keyword.get(opts, :order, :asc))
+
+        limit =
+          normalize_non_negative_integer(
+            Keyword.get(opts, :limit, @default_read_limit),
+            @default_read_limit
+          )
+
+        offset = normalize_non_negative_integer(Keyword.get(opts, :offset, 0), 0)
+        after_seq = normalize_optional_integer(Keyword.get(opts, :after_seq))
+        before_seq = normalize_optional_integer(Keyword.get(opts, :before_seq))
+
+        @events_table
+        |> :ets.tab2list()
+        |> Enum.reduce([], fn
+          {{^stream, seq}, event}, acc ->
+            if seq_in_range?(seq, after_seq, before_seq) do
+              [event | acc]
+            else
+              acc
+            end
+
+          _, acc ->
+            acc
+        end)
+        |> Enum.sort_by(&Map.get(&1, :seq, 0), order)
+        |> Enum.drop(offset)
+        |> maybe_take(limit)
+
+      {:error, _reason} ->
+        []
+    end
+  end
+
+  def read_events(_stream, _opts), do: []
+
+  @impl true
+  def handle_call({:append_event, stream, event}, _from, state) do
+    seq = Map.get(state.seq_by_stream, stream, 0) + 1
+    now = now_ms()
+
+    normalized_event =
+      event
+      |> Map.put(:stream, stream)
+      |> Map.put(:seq, seq)
+      |> Map.put_new(:inserted_at, now)
+
+    :ets.insert(@events_table, {{stream, seq}, normalized_event})
+    :ets.insert(@seq_table, {stream, seq})
+
+    if seq > state.event_retention do
+      prune_key = {stream, seq - state.event_retention}
+      :ets.delete(@events_table, prune_key)
+    end
+
+    {:reply, {:ok, normalized_event},
+     %{state | seq_by_stream: Map.put(state.seq_by_stream, stream, seq)}}
+  end
+
+  defp ensure_started do
+    case Process.whereis(__MODULE__) do
+      pid when is_pid(pid) ->
+        :ok
+
+      nil ->
+        case start_link([]) do
+          {:ok, _pid} -> :ok
+          {:error, {:already_started, _pid}} -> :ok
+          {:error, reason} -> {:error, reason}
+        end
+    end
+  end
+
+  defp ensure_tables do
+    ensure_table(@docs_table, [:set, :named_table, :public, read_concurrency: true])
+
+    ensure_table(@events_table, [
+      :ordered_set,
+      :named_table,
+      :public,
+      read_concurrency: true,
+      write_concurrency: true
+    ])
+
+    ensure_table(@seq_table, [:set, :named_table, :public])
+  end
+
+  defp ensure_table(table, options) do
+    case :ets.info(table) do
+      :undefined ->
+        :ets.new(table, options)
+        :ok
+
+      _ ->
+        :ok
+    end
+  rescue
+    _ -> :ok
+  end
+
+  defp normalize_namespace(namespace) when is_atom(namespace), do: Atom.to_string(namespace)
+  defp normalize_namespace(namespace) when is_binary(namespace), do: namespace
+  defp normalize_namespace(namespace), do: to_string(namespace)
+
+  defp normalize_id(id) when is_binary(id), do: id
+  defp normalize_id(id) when is_atom(id), do: Atom.to_string(id)
+  defp normalize_id(id), do: to_string(id)
+
+  defp normalize_optional_string(value) when is_binary(value) and value != "", do: value
+  defp normalize_optional_string(_), do: nil
+
+  defp normalize_optional_integer(value) when is_integer(value), do: value
+  defp normalize_optional_integer(_), do: nil
+
+  defp normalize_positive_integer(value, _default) when is_integer(value) and value > 0, do: value
+  defp normalize_positive_integer(_value, default), do: default
+
+  defp normalize_non_negative_integer(value, _default) when is_integer(value) and value >= 0,
+    do: value
+
+  defp normalize_non_negative_integer(_value, default), do: default
+
+  defp normalize_order(:asc), do: :asc
+  defp normalize_order(:desc), do: :desc
+  defp normalize_order(_), do: :desc
+
+  defp sort_value(doc, key) when is_map(doc) do
+    Map.get(doc, key, Map.get(doc, :updated_at, 0))
+  end
+
+  defp sort_value(_, _), do: 0
+
+  defp maybe_take(list, 0), do: list
+  defp maybe_take(list, limit), do: Enum.take(list, limit)
+
+  defp seq_in_range?(seq, after_seq, before_seq) when is_integer(seq) do
+    after_ok = is_nil(after_seq) or seq > after_seq
+    before_ok = is_nil(before_seq) or seq < before_seq
+    after_ok and before_ok
+  end
+
+  defp seq_in_range?(_, _, _), do: false
+
+  defp now_ms, do: System.system_time(:millisecond)
+end

--- a/lib/jido_studio/router.ex
+++ b/lib/jido_studio/router.ex
@@ -90,12 +90,22 @@ defmodule JidoStudio.Router do
           Phoenix.LiveView.Router.live("/agents", JidoStudio.AgentsLive, :index)
           Phoenix.LiveView.Router.live("/agents/:slug/:instance_id", JidoStudio.AgentsLive, :show)
           Phoenix.LiveView.Router.live("/agents/:slug", JidoStudio.AgentsLive, :show)
+          Phoenix.LiveView.Router.live("/registry", JidoStudio.RegistryLive, :index)
+          Phoenix.LiveView.Router.live("/threads", JidoStudio.ThreadsLive, :index)
+
+          Phoenix.LiveView.Router.live(
+            "/threads/:agent_slug/:instance_id/:thread_id",
+            JidoStudio.ThreadsLive,
+            :show
+          )
+
           Phoenix.LiveView.Router.live("/actions", JidoStudio.ActionsLive, :index)
           Phoenix.LiveView.Router.live("/actions/:id", JidoStudio.ActionsLive, :show)
           Phoenix.LiveView.Router.live("/workflows", JidoStudio.WorkflowsLive, :index)
           Phoenix.LiveView.Router.live("/workflows/:id", JidoStudio.WorkflowsLive, :show)
           Phoenix.LiveView.Router.live("/signals", JidoStudio.SignalsLive, :index)
           Phoenix.LiveView.Router.live("/traces", JidoStudio.TracesLive, :index)
+          Phoenix.LiveView.Router.live("/traces/:trace_id", JidoStudio.TracesLive, :show)
           Phoenix.LiveView.Router.live("/settings", JidoStudio.SettingsLive, :index)
         end
       end

--- a/lib/jido_studio/runtime.ex
+++ b/lib/jido_studio/runtime.ex
@@ -20,10 +20,13 @@ defmodule JidoStudio.Runtime do
 
   @impl true
   def init(opts) do
-    children = [
-      {JidoStudio.TraceBuffer, opts},
-      {JidoStudio.Threads.Manager, opts}
-    ]
+    children =
+      JidoStudio.Persistence.child_specs(opts) ++
+        [
+          {JidoStudio.Ingestor, opts},
+          {JidoStudio.TraceBuffer, opts},
+          {JidoStudio.Threads.Manager, opts}
+        ]
 
     Supervisor.init(children, strategy: :one_for_one)
   end

--- a/lib/jido_studio/threads.ex
+++ b/lib/jido_studio/threads.ex
@@ -1,0 +1,183 @@
+defmodule JidoStudio.Threads do
+  @moduledoc false
+
+  alias JidoStudio.Threads.Codec
+  alias JidoStudio.Threads.Storage
+
+  @spec list_threads(keyword()) :: [map()]
+  def list_threads(opts \\ []) do
+    query =
+      opts
+      |> Keyword.get(:query)
+      |> normalize_optional_string()
+
+    with {:ok, index} <- Storage.load_workspace_index(storage_opts(opts)) do
+      index.items
+      |> Enum.flat_map(fn {_workspace_id, item} ->
+        list_threads_for_workspace(item, opts)
+      end)
+      |> maybe_filter_query(query)
+      |> Enum.sort_by(&Map.get(&1, :updated_at, 0), :desc)
+    else
+      _ ->
+        []
+    end
+  end
+
+  @spec get_thread(String.t(), String.t(), String.t(), keyword()) ::
+          {:ok, map()} | :not_found | {:error, term()}
+  def get_thread(agent_slug, instance_id, thread_id, opts \\ [])
+
+  def get_thread(agent_slug, instance_id, thread_id, opts)
+      when is_binary(agent_slug) and is_binary(instance_id) and is_binary(thread_id) do
+    thread_key = Storage.thread_key(agent_slug, instance_id, thread_id)
+
+    case Storage.load_thread(thread_key, storage_opts(opts)) do
+      {:ok, thread} ->
+        {:ok,
+         %{
+           thread: %{
+             agent_slug: agent_slug,
+             instance_id: instance_id,
+             thread_id: thread_id,
+             rev: thread.rev,
+             entry_count: length(thread.entries || []),
+             updated_at: latest_entry_time(thread.entries)
+           },
+           entries: Enum.map(thread.entries || [], &entry_view/1)
+         }}
+
+      :not_found ->
+        :not_found
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  rescue
+    error -> {:error, Exception.message(error)}
+  end
+
+  def get_thread(_, _, _, _), do: :not_found
+
+  defp list_threads_for_workspace(item, opts) do
+    agent_slug = item[:agent_slug] || item["agent_slug"]
+    instance_id = item[:instance_id] || item["instance_id"]
+
+    if is_binary(agent_slug) and is_binary(instance_id) do
+      case Storage.get_workspace_checkpoint(agent_slug, instance_id, storage_opts(opts)) do
+        {:ok, checkpoint} ->
+          checkpoint
+          |> Codec.decode_workspace_checkpoint()
+          |> Map.get(:threads, [])
+          |> Enum.map(fn thread ->
+            %{
+              thread_id: thread.id,
+              title: thread.title,
+              entry_count: thread.message_count,
+              rev: thread.journal_rev,
+              updated_at: thread.updated_at,
+              agent_slug: agent_slug,
+              agent_id: instance_id,
+              instance_id: instance_id
+            }
+          end)
+
+        _ ->
+          []
+      end
+    else
+      []
+    end
+  end
+
+  defp entry_view(entry) do
+    payload = normalize_map(entry.payload)
+    refs = normalize_map(entry.refs)
+
+    %{
+      seq: entry.seq,
+      at: entry.at,
+      kind: entry.kind,
+      payload: payload,
+      payload_preview: payload_preview(payload),
+      refs: refs,
+      trace_id: trace_id_from(payload, refs),
+      span_id: span_id_from(payload, refs)
+    }
+  end
+
+  defp payload_preview(payload) when is_map(payload) do
+    cond do
+      is_binary(get_in(payload, [:message, :content])) ->
+        get_in(payload, [:message, :content])
+        |> String.replace(~r/\s+/, " ")
+        |> String.trim()
+        |> String.slice(0, 120)
+
+      is_binary(payload[:content]) ->
+        payload[:content]
+        |> String.replace(~r/\s+/, " ")
+        |> String.trim()
+        |> String.slice(0, 120)
+
+      true ->
+        inspect(payload, limit: 6, printable_limit: 800)
+    end
+  end
+
+  defp payload_preview(payload), do: inspect(payload, limit: 6, printable_limit: 800)
+
+  defp trace_id_from(payload, refs) do
+    refs[:trace_id] || refs["trace_id"] || payload[:trace_id] || payload["trace_id"] ||
+      payload[:jido_trace_id] || payload["jido_trace_id"]
+  end
+
+  defp span_id_from(payload, refs) do
+    refs[:span_id] || refs["span_id"] || payload[:span_id] || payload["span_id"] ||
+      payload[:jido_span_id] || payload["jido_span_id"]
+  end
+
+  defp latest_entry_time(entries) when is_list(entries) do
+    entries
+    |> Enum.map(&Map.get(&1, :at, 0))
+    |> Enum.max(fn -> 0 end)
+  end
+
+  defp latest_entry_time(_), do: 0
+
+  defp maybe_filter_query(threads, nil), do: threads
+
+  defp maybe_filter_query(threads, query) do
+    q = String.downcase(query)
+
+    Enum.filter(threads, fn thread ->
+      searchable =
+        [
+          thread.thread_id,
+          thread.title,
+          thread.agent_slug,
+          thread.agent_id
+        ]
+        |> Enum.filter(&is_binary/1)
+        |> Enum.join(" ")
+        |> String.downcase()
+
+      String.contains?(searchable, q)
+    end)
+  end
+
+  defp normalize_map(map) when is_map(map), do: map
+  defp normalize_map(_), do: %{}
+
+  defp normalize_optional_string(value) when is_binary(value) and value != "", do: value
+  defp normalize_optional_string(_), do: nil
+
+  defp storage_opts(opts) do
+    []
+    |> maybe_put(:jido_instance, Keyword.get(opts, :jido_instance))
+    |> maybe_put(:thread_storage_mode, Keyword.get(opts, :thread_storage_mode))
+  end
+
+  defp maybe_put(opts, _key, nil), do: opts
+  defp maybe_put(opts, key, value), do: Keyword.put(opts, key, value)
+end

--- a/lib/jido_studio/threads/codec.ex
+++ b/lib/jido_studio/threads/codec.ex
@@ -56,16 +56,30 @@ defmodule JidoStudio.Threads.Codec do
   def decode_workspace_checkpoint(%{} = checkpoint) do
     %{
       schema_version:
-        normalize_non_neg_integer(Map.get(checkpoint, :schema_version) || Map.get(checkpoint, "schema_version")),
+        normalize_non_neg_integer(
+          Map.get(checkpoint, :schema_version) || Map.get(checkpoint, "schema_version")
+        ),
       active_thread_id:
         normalize_optional_binary(
           Map.get(checkpoint, :active_thread_id) || Map.get(checkpoint, "active_thread_id")
         ),
       draft_message:
-        normalize_optional_binary(Map.get(checkpoint, :draft_message) || Map.get(checkpoint, "draft_message")),
-      updated_at: normalize_integer(Map.get(checkpoint, :updated_at) || Map.get(checkpoint, "updated_at"), now_ms()),
-      instance_binding: normalize_map(Map.get(checkpoint, :instance_binding) || Map.get(checkpoint, "instance_binding") || %{}),
-      thread_contexts: normalize_map(Map.get(checkpoint, :thread_contexts) || Map.get(checkpoint, "thread_contexts") || %{}),
+        normalize_optional_binary(
+          Map.get(checkpoint, :draft_message) || Map.get(checkpoint, "draft_message")
+        ),
+      updated_at:
+        normalize_integer(
+          Map.get(checkpoint, :updated_at) || Map.get(checkpoint, "updated_at"),
+          now_ms()
+        ),
+      instance_binding:
+        normalize_map(
+          Map.get(checkpoint, :instance_binding) || Map.get(checkpoint, "instance_binding") || %{}
+        ),
+      thread_contexts:
+        normalize_map(
+          Map.get(checkpoint, :thread_contexts) || Map.get(checkpoint, "thread_contexts") || %{}
+        ),
       threads:
         normalize_thread_records(
           Map.get(checkpoint, :threads) || Map.get(checkpoint, "threads") || []
@@ -93,13 +107,13 @@ defmodule JidoStudio.Threads.Codec do
       hashes = Map.put(hashes, message_id, hash)
 
       if Map.get(known_hashes, message_id) != hash do
-          payload = %{
-            event: :upsert_message,
-            message_id: message_id,
-            message: normalized,
-            hash: hash,
-            persisted_at: now_ms()
-          }
+        payload = %{
+          event: :upsert_message,
+          message_id: message_id,
+          message: normalized,
+          hash: hash,
+          persisted_at: now_ms()
+        }
 
         entry = %Entry{id: nil, seq: 0, at: now_ms(), kind: :message, payload: payload, refs: %{}}
         {[entry | entries], hashes}
@@ -207,7 +221,11 @@ defmodule JidoStudio.Threads.Codec do
     end
   end
 
-  defp normalize_chat_state(%{threads: threads, active_thread_id: active_thread_id, messages_by_thread: by_thread})
+  defp normalize_chat_state(%{
+         threads: threads,
+         active_thread_id: active_thread_id,
+         messages_by_thread: by_thread
+       })
        when is_list(threads) and is_map(by_thread) do
     %{
       threads: normalize_thread_records(threads),
@@ -224,14 +242,27 @@ defmodule JidoStudio.Threads.Codec do
     |> Enum.map(fn thread ->
       %{
         id: normalize_optional_binary(Map.get(thread, :id) || Map.get(thread, "id") || ""),
-        title: normalize_optional_binary(Map.get(thread, :title) || Map.get(thread, "title") || "New Chat"),
+        title:
+          normalize_optional_binary(
+            Map.get(thread, :title) || Map.get(thread, "title") || "New Chat"
+          ),
         message_count:
-          normalize_non_neg_integer(Map.get(thread, :message_count) || Map.get(thread, "message_count")),
-        updated_at: normalize_integer(Map.get(thread, :updated_at) || Map.get(thread, "updated_at"), now_ms()),
+          normalize_non_neg_integer(
+            Map.get(thread, :message_count) || Map.get(thread, "message_count")
+          ),
+        updated_at:
+          normalize_integer(
+            Map.get(thread, :updated_at) || Map.get(thread, "updated_at"),
+            now_ms()
+          ),
         journal_rev:
-          normalize_non_neg_integer(Map.get(thread, :journal_rev) || Map.get(thread, "journal_rev")),
+          normalize_non_neg_integer(
+            Map.get(thread, :journal_rev) || Map.get(thread, "journal_rev")
+          ),
         message_hashes:
-          normalize_hashes(Map.get(thread, :message_hashes) || Map.get(thread, "message_hashes") || %{})
+          normalize_hashes(
+            Map.get(thread, :message_hashes) || Map.get(thread, "message_hashes") || %{}
+          )
       }
     end)
     |> Enum.filter(&(is_binary(&1.id) and &1.id != ""))
@@ -247,7 +278,8 @@ defmodule JidoStudio.Threads.Codec do
     end
   end
 
-  defp normalize_active_thread_id(active_thread_id, messages_by_thread) when is_binary(active_thread_id) do
+  defp normalize_active_thread_id(active_thread_id, messages_by_thread)
+       when is_binary(active_thread_id) do
     if Map.has_key?(messages_by_thread, active_thread_id) do
       active_thread_id
     else
@@ -255,15 +287,22 @@ defmodule JidoStudio.Threads.Codec do
     end
   end
 
-  defp normalize_active_thread_id(_, messages_by_thread), do: normalize_active_thread_id(nil, messages_by_thread)
+  defp normalize_active_thread_id(_, messages_by_thread),
+    do: normalize_active_thread_id(nil, messages_by_thread)
 
   defp normalize_message(message) when is_map(message) do
     %{
       id:
-        normalize_optional_binary(Map.get(message, :id) || Map.get(message, "id") || generated_message_id()),
+        normalize_optional_binary(
+          Map.get(message, :id) || Map.get(message, "id") || generated_message_id()
+        ),
       role: normalize_role(Map.get(message, :role) || Map.get(message, "role")),
-      content: normalize_optional_binary(Map.get(message, :content) || Map.get(message, "content")),
-      tool_events: normalize_tool_events(Map.get(message, :tool_events) || Map.get(message, "tool_events") || []),
+      content:
+        normalize_optional_binary(Map.get(message, :content) || Map.get(message, "content")),
+      tool_events:
+        normalize_tool_events(
+          Map.get(message, :tool_events) || Map.get(message, "tool_events") || []
+        ),
       state: normalize_message_state(Map.get(message, :state) || Map.get(message, "state")),
       at: normalize_integer(Map.get(message, :at) || Map.get(message, "at"), now_ms())
     }

--- a/lib/jido_studio/threads/manager.ex
+++ b/lib/jido_studio/threads/manager.ex
@@ -20,7 +20,8 @@ defmodule JidoStudio.Threads.Manager do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
-  @spec load_workspace(String.t(), String.t(), keyword()) :: {:ok, workspace_payload()} | {:error, term()}
+  @spec load_workspace(String.t(), String.t(), keyword()) ::
+          {:ok, workspace_payload()} | {:error, term()}
   def load_workspace(agent_slug, instance_id, opts \\ []) do
     with {:ok, _pid} <- ensure_started() do
       safe_call(
@@ -82,12 +83,22 @@ defmodule JidoStudio.Threads.Manager do
       case Storage.get_workspace_checkpoint(agent_slug, instance_id, storage_opts) do
         {:ok, %{} = checkpoint} ->
           decoded = Codec.decode_workspace_checkpoint(checkpoint)
-          {messages_by_thread, threads} = load_thread_messages(agent_slug, instance_id, decoded, storage_opts)
+
+          {messages_by_thread, threads} =
+            load_thread_messages(agent_slug, instance_id, decoded, storage_opts)
+
           chat_state = Codec.workspace_from_checkpoint(decoded, messages_by_thread)
 
           {:ok,
-           Codec.workspace_payload(decoded, chat_state, %{agent_slug: agent_slug, instance_id: instance_id})
-           |> Map.put(:chat_state, %{chat_state | threads: threads, messages_by_thread: messages_by_thread})}
+           Codec.workspace_payload(decoded, chat_state, %{
+             agent_slug: agent_slug,
+             instance_id: instance_id
+           })
+           |> Map.put(:chat_state, %{
+             chat_state
+             | threads: threads,
+               messages_by_thread: messages_by_thread
+           })}
 
         :not_found ->
           {:ok, Codec.empty_workspace_payload()}
@@ -120,7 +131,8 @@ defmodule JidoStudio.Threads.Manager do
 
       with {:ok, updated_records} <-
              sync_threads(agent_slug, instance_id, state, existing_records, storage_opts),
-           :ok <- prune_deleted_threads(agent_slug, instance_id, state, existing_records, storage_opts),
+           :ok <-
+             prune_deleted_threads(agent_slug, instance_id, state, existing_records, storage_opts),
            :ok <-
              persist_workspace_checkpoint(
                agent_slug,
@@ -191,7 +203,11 @@ defmodule JidoStudio.Threads.Manager do
     else
       expected_rev = existing_record.journal_rev
 
-      case Storage.append_thread(thread_key, entries, Keyword.put(storage_opts, :expected_rev, expected_rev)) do
+      case Storage.append_thread(
+             thread_key,
+             entries,
+             Keyword.put(storage_opts, :expected_rev, expected_rev)
+           ) do
         {:ok, thread} ->
           {:ok,
            %{
@@ -273,7 +289,11 @@ defmodule JidoStudio.Threads.Manager do
 
     with {:ok, index} <- Storage.load_workspace_index(storage_opts) do
       items =
-        Map.put(index.items, workspace_id, %{agent_slug: agent_slug, instance_id: instance_id, updated_at: now_ms()})
+        Map.put(index.items, workspace_id, %{
+          agent_slug: agent_slug,
+          instance_id: instance_id,
+          updated_at: now_ms()
+        })
 
       Storage.put_workspace_index(%{index | items: items, updated_at: now_ms()}, storage_opts)
     end
@@ -384,7 +404,11 @@ defmodule JidoStudio.Threads.Manager do
     }
   end
 
-  defp normalize_chat_state(%{threads: threads, active_thread_id: active_thread_id, messages_by_thread: by_thread})
+  defp normalize_chat_state(%{
+         threads: threads,
+         active_thread_id: active_thread_id,
+         messages_by_thread: by_thread
+       })
        when is_list(threads) and is_map(by_thread) do
     %{threads: threads, active_thread_id: active_thread_id, messages_by_thread: by_thread}
   end

--- a/lib/jido_studio/threads/storage.ex
+++ b/lib/jido_studio/threads/storage.ex
@@ -49,12 +49,14 @@ defmodule JidoStudio.Threads.Storage do
   end
 
   @spec workspace_key(String.t(), String.t()) :: tuple()
-  def workspace_key(agent_slug, instance_id) when is_binary(agent_slug) and is_binary(instance_id) do
+  def workspace_key(agent_slug, instance_id)
+      when is_binary(agent_slug) and is_binary(instance_id) do
     {:studio_workspace, agent_slug, instance_id}
   end
 
   @spec workspace_id(String.t(), String.t()) :: String.t()
-  def workspace_id(agent_slug, instance_id) when is_binary(agent_slug) and is_binary(instance_id) do
+  def workspace_id(agent_slug, instance_id)
+      when is_binary(agent_slug) and is_binary(instance_id) do
     "#{agent_slug}::#{instance_id}"
   end
 
@@ -75,11 +77,13 @@ defmodule JidoStudio.Threads.Storage do
 
   @spec put_workspace_checkpoint(String.t(), String.t(), map(), storage_opts()) ::
           :ok | {:error, term()}
-  def put_workspace_checkpoint(agent_slug, instance_id, checkpoint, opts \\ []) when is_map(checkpoint) do
+  def put_workspace_checkpoint(agent_slug, instance_id, checkpoint, opts \\ [])
+      when is_map(checkpoint) do
     put_checkpoint(workspace_key(agent_slug, instance_id), checkpoint, opts)
   end
 
-  @spec delete_workspace_checkpoint(String.t(), String.t(), storage_opts()) :: :ok | {:error, term()}
+  @spec delete_workspace_checkpoint(String.t(), String.t(), storage_opts()) ::
+          :ok | {:error, term()}
   def delete_workspace_checkpoint(agent_slug, instance_id, opts \\ []) do
     delete_checkpoint(workspace_key(agent_slug, instance_id), opts)
   end
@@ -115,7 +119,8 @@ defmodule JidoStudio.Threads.Storage do
 
   @spec append_thread(String.t(), [Jido.Thread.Entry.t()], storage_opts()) ::
           {:ok, Jido.Thread.t()} | {:error, term()}
-  def append_thread(thread_key, entries, opts \\ []) when is_binary(thread_key) and is_list(entries) do
+  def append_thread(thread_key, entries, opts \\ [])
+      when is_binary(thread_key) and is_list(entries) do
     with {:ok, {adapter, adapter_opts}} <- resolve_storage(opts) do
       expected_rev = Keyword.get(opts, :expected_rev)
 
@@ -167,7 +172,8 @@ defmodule JidoStudio.Threads.Storage do
   def normalize_workspace_index(index) when is_map(index) do
     %{
       schema_version: @workspace_index_version,
-      updated_at: normalize_integer(Map.get(index, :updated_at) || Map.get(index, "updated_at"), now_ms()),
+      updated_at:
+        normalize_integer(Map.get(index, :updated_at) || Map.get(index, "updated_at"), now_ms()),
       items: normalize_index_items(Map.get(index, :items) || Map.get(index, "items") || %{})
     }
   end
@@ -249,7 +255,8 @@ defmodule JidoStudio.Threads.Storage do
     |> Enum.map(&sanitize_term(&1, depth + 1))
   end
 
-  defp sanitize_term(binary, _depth) when is_binary(binary) and byte_size(binary) > @max_binary_size do
+  defp sanitize_term(binary, _depth)
+       when is_binary(binary) and byte_size(binary) > @max_binary_size do
     binary_part(binary, 0, @max_binary_size) <> "...[truncated]"
   end
 

--- a/lib/jido_studio/trace_buffer.ex
+++ b/lib/jido_studio/trace_buffer.ex
@@ -2,6 +2,7 @@ defmodule JidoStudio.TraceBuffer do
   @moduledoc false
   use GenServer
 
+  alias JidoStudio.Ingestor
   alias JidoStudio.TraceCatalog
 
   @default_size 5000
@@ -185,6 +186,7 @@ defmodule JidoStudio.TraceBuffer do
       )
 
     :ets.insert(@table, {counter, normalized})
+    Ingestor.ingest_event(normalized)
 
     if counter > state.size do
       case :ets.first(@table) do

--- a/lib/jido_studio/tracing.ex
+++ b/lib/jido_studio/tracing.ex
@@ -1,0 +1,261 @@
+defmodule JidoStudio.Tracing do
+  @moduledoc false
+
+  alias JidoStudio.Persistence
+
+  @traces_namespace "traces"
+  @spans_namespace "spans"
+  @default_limit 200
+
+  @spec list_traces(keyword()) :: [map()]
+  def list_traces(opts \\ []) do
+    filters = Keyword.get(opts, :filters, %{})
+    limit = normalize_limit(Keyword.get(opts, :limit, @default_limit))
+
+    Persistence.list_docs(@traces_namespace,
+      order: :desc,
+      limit: max(limit * 5, 500),
+      sort_by: :last_event_at
+    )
+    |> Enum.filter(&trace_matches_filters?(&1, filters))
+    |> Enum.sort_by(&trace_sort_key/1, :desc)
+    |> Enum.take(limit)
+  end
+
+  @spec get_trace(String.t()) :: {:ok, map()} | :not_found | {:error, term()}
+  def get_trace(trace_id) when is_binary(trace_id) do
+    Persistence.get_doc(@traces_namespace, trace_id)
+  end
+
+  def get_trace(_), do: :not_found
+
+  @spec list_trace_events(String.t(), keyword()) :: [map()]
+  def list_trace_events(trace_id, opts \\ [])
+
+  def list_trace_events(trace_id, opts) when is_binary(trace_id) do
+    limit = normalize_limit(Keyword.get(opts, :limit, 500))
+
+    Persistence.read_events("trace:" <> trace_id,
+      order: normalize_order(Keyword.get(opts, :order, :asc)),
+      limit: limit,
+      after_seq: Keyword.get(opts, :after_seq),
+      before_seq: Keyword.get(opts, :before_seq)
+    )
+  end
+
+  def list_trace_events(_, _), do: []
+
+  @spec list_trace_spans(String.t(), keyword()) :: [map()]
+  def list_trace_spans(trace_id, opts \\ [])
+
+  def list_trace_spans(trace_id, opts) when is_binary(trace_id) do
+    limit = normalize_limit(Keyword.get(opts, :limit, 3_000))
+
+    spans =
+      Persistence.list_docs(@spans_namespace,
+        id_prefix: trace_id <> ":",
+        order: :asc,
+        sort_by: :started_at,
+        limit: limit
+      )
+
+    trace_started_at =
+      case get_trace(trace_id) do
+        {:ok, trace} -> Map.get(trace, :started_at)
+        _ -> nil
+      end
+
+    decorate_span_hierarchy(spans, trace_started_at)
+  end
+
+  def list_trace_spans(_, _), do: []
+
+  defp trace_matches_filters?(trace, filters) when is_map(trace) do
+    status_filter =
+      normalize_status_filter(Map.get(filters, :status) || Map.get(filters, "status"))
+
+    agent_filter =
+      normalize_optional_string(Map.get(filters, :agent) || Map.get(filters, "agent"))
+
+    {from_ms, to_ms} =
+      time_range_bounds(
+        Map.get(filters, :range) || Map.get(filters, "range"),
+        Map.get(filters, :from) || Map.get(filters, "from"),
+        Map.get(filters, :to) || Map.get(filters, "to")
+      )
+
+    status_ok =
+      case status_filter do
+        nil -> true
+        "all" -> true
+        status -> normalize_optional_string(Map.get(trace, :status)) == status
+      end
+
+    agent_ok =
+      case agent_filter do
+        nil ->
+          true
+
+        value ->
+          trace
+          |> Map.get(:agent_id)
+          |> normalize_optional_string()
+          |> case do
+            nil -> false
+            trace_agent -> String.contains?(String.downcase(trace_agent), String.downcase(value))
+          end
+      end
+
+    ts = trace_time(trace)
+    time_ok = within_time_bounds?(ts, from_ms, to_ms)
+
+    status_ok and agent_ok and time_ok
+  end
+
+  defp trace_matches_filters?(_, _), do: false
+
+  defp trace_time(trace) when is_map(trace) do
+    Map.get(trace, :started_at) || Map.get(trace, :last_event_at)
+  end
+
+  defp trace_sort_key(trace) when is_map(trace) do
+    Map.get(trace, :started_at) || Map.get(trace, :last_event_at) || 0
+  end
+
+  defp normalize_status_filter(nil), do: nil
+
+  defp normalize_status_filter(value) when is_binary(value) do
+    normalized = value |> String.trim() |> String.downcase()
+
+    if normalized in ["running", "ok", "error", "all"] do
+      normalized
+    else
+      nil
+    end
+  end
+
+  defp normalize_status_filter(value) when is_atom(value) do
+    value
+    |> Atom.to_string()
+    |> normalize_status_filter()
+  end
+
+  defp normalize_status_filter(_), do: nil
+
+  defp normalize_optional_string(value) when is_binary(value) and value != "", do: value
+  defp normalize_optional_string(value) when is_atom(value), do: Atom.to_string(value)
+  defp normalize_optional_string(_), do: nil
+
+  defp time_range_bounds(range, from, to) do
+    case normalize_optional_string(range) do
+      "15m" -> {now_ms() - :timer.minutes(15), now_ms()}
+      "1h" -> {now_ms() - :timer.hours(1), now_ms()}
+      "24h" -> {now_ms() - :timer.hours(24), now_ms()}
+      "custom" -> {parse_datetime_local(from), parse_datetime_local(to)}
+      _ -> {now_ms() - :timer.hours(1), now_ms()}
+    end
+  end
+
+  defp within_time_bounds?(_timestamp, nil, nil), do: true
+  defp within_time_bounds?(nil, _from_ms, _to_ms), do: false
+
+  defp within_time_bounds?(timestamp, from_ms, to_ms) do
+    from_ok = is_nil(from_ms) or timestamp >= from_ms
+    to_ok = is_nil(to_ms) or timestamp <= to_ms
+    from_ok and to_ok
+  end
+
+  defp parse_datetime_local(value) when is_binary(value) and value != "" do
+    case NaiveDateTime.from_iso8601(value <> ":00") do
+      {:ok, naive} ->
+        naive
+        |> DateTime.from_naive!("Etc/UTC")
+        |> DateTime.to_unix(:millisecond)
+
+      _ ->
+        nil
+    end
+  end
+
+  defp parse_datetime_local(_), do: nil
+
+  defp decorate_span_hierarchy(spans, trace_started_at) do
+    spans_by_id = Map.new(spans, fn span -> {span[:span_id], span} end)
+
+    children_by_parent =
+      Enum.reduce(spans, %{}, fn span, acc ->
+        parent = span[:parent_span_id]
+        Map.update(acc, parent, [span], fn existing -> [span | existing] end)
+      end)
+
+    roots =
+      spans
+      |> Enum.filter(fn span ->
+        parent = span[:parent_span_id]
+        is_nil(parent) or not Map.has_key?(spans_by_id, parent)
+      end)
+      |> Enum.sort_by(&span_sort_key/1, :asc)
+
+    ordered =
+      Enum.flat_map(roots, fn root ->
+        flatten_span_tree(root, children_by_parent, 0)
+      end)
+
+    # If cycles/orphans exist, ensure every span still appears once.
+    seen = MapSet.new(Enum.map(ordered, & &1[:span_id]))
+
+    extra =
+      spans
+      |> Enum.reject(&MapSet.member?(seen, &1[:span_id]))
+      |> Enum.sort_by(&span_sort_key/1, :asc)
+      |> Enum.map(&decorate_span(&1, 0, trace_started_at))
+
+    (ordered ++ extra)
+    |> Enum.map(&decorate_span_offsets(&1, trace_started_at))
+  end
+
+  defp flatten_span_tree(span, children_by_parent, depth) do
+    decorated = Map.put(span, :depth, depth)
+
+    children =
+      children_by_parent
+      |> Map.get(span[:span_id], [])
+      |> Enum.sort_by(&span_sort_key/1, :asc)
+
+    [decorated | Enum.flat_map(children, &flatten_span_tree(&1, children_by_parent, depth + 1))]
+  end
+
+  defp decorate_span(span, depth, trace_started_at) do
+    span
+    |> Map.put(:depth, depth)
+    |> decorate_span_offsets(trace_started_at)
+  end
+
+  defp decorate_span_offsets(span, trace_started_at) do
+    started_at = span[:started_at]
+
+    offset_ms =
+      if is_integer(started_at) and is_integer(trace_started_at) do
+        max(started_at - trace_started_at, 0)
+      else
+        nil
+      end
+
+    Map.put(span, :offset_ms, offset_ms)
+  end
+
+  defp span_sort_key(span) when is_map(span) do
+    span[:started_at] || span[:last_event_at] || 0
+  end
+
+  defp normalize_limit(value) when is_integer(value) and value > 0, do: value
+  defp normalize_limit(_), do: @default_limit
+
+  defp normalize_order(:asc), do: :asc
+  defp normalize_order(:desc), do: :desc
+  defp normalize_order("asc"), do: :asc
+  defp normalize_order("desc"), do: :desc
+  defp normalize_order(_), do: :asc
+
+  defp now_ms, do: System.system_time(:millisecond)
+end

--- a/mix.exs
+++ b/mix.exs
@@ -60,7 +60,7 @@ defmodule JidoStudio.MixProject do
 
   defp package do
     [
-      files: ["lib", "priv/static", "mix.exs", "README.md", "LICENSE"],
+      files: ["lib", "priv/static", "priv/ecto", "mix.exs", "README.md", "LICENSE"],
       maintainers: ["Mike Hostetler"],
       licenses: ["Apache-2.0"],
       links: %{

--- a/priv/ecto/migrations/20260215000000_create_jido_studio_persistence_tables.exs
+++ b/priv/ecto/migrations/20260215000000_create_jido_studio_persistence_tables.exs
@@ -1,0 +1,25 @@
+defmodule JidoStudio.PersistenceMigration do
+  use Ecto.Migration
+
+  def change do
+    create table(:jido_studio_docs, primary_key: false) do
+      add :namespace, :string, null: false
+      add :doc_id, :string, null: false
+      add :data, :map, null: false
+      timestamps(updated_at: :updated_at, inserted_at: :inserted_at, type: :utc_datetime_usec)
+    end
+
+    create unique_index(:jido_studio_docs, [:namespace, :doc_id],
+             name: :jido_studio_docs_namespace_doc_id_index
+           )
+
+    create table(:jido_studio_events, primary_key: false) do
+      add :seq, :bigserial, primary_key: true
+      add :stream, :string, null: false
+      add :event, :map, null: false
+      timestamps(updated_at: false, inserted_at: :inserted_at, type: :utc_datetime_usec)
+    end
+
+    create index(:jido_studio_events, [:stream, :seq], name: :jido_studio_events_stream_seq_index)
+  end
+end

--- a/test/jido_studio/ingestor_tracing_test.exs
+++ b/test/jido_studio/ingestor_tracing_test.exs
@@ -1,0 +1,101 @@
+defmodule JidoStudio.IngestorTracingTest do
+  use ExUnit.Case, async: false
+
+  alias JidoStudio.Ingestor
+  alias JidoStudio.Tracing
+
+  setup do
+    old_persistence = Application.get_env(:jido_studio, :persistence)
+
+    Application.put_env(:jido_studio, :persistence,
+      adapter: JidoStudio.Persistence.ETS,
+      opts: [event_retention: 200]
+    )
+
+    clear_table(:jido_studio_persistence_docs)
+    clear_table(:jido_studio_persistence_events)
+    clear_table(:jido_studio_persistence_event_seq)
+
+    on_exit(fn ->
+      Application.put_env(:jido_studio, :persistence, old_persistence)
+    end)
+
+    :ok
+  end
+
+  test "ingestor materializes trace and span docs" do
+    t0 = System.system_time(:millisecond)
+
+    Ingestor.ingest_event(%{
+      trace_id: "trace-abc",
+      span_id: "span-root",
+      parent_span_id: nil,
+      agent_id: "weather-agent-1",
+      type: :start,
+      event_name: "jido.agent.cmd.start",
+      timestamp_ms: t0,
+      metadata: %{}
+    })
+
+    Ingestor.ingest_event(%{
+      trace_id: "trace-abc",
+      span_id: "span-child",
+      parent_span_id: "span-root",
+      agent_id: "weather-agent-1",
+      type: :start,
+      event_name: "jido.ai.tool.execute.start",
+      timestamp_ms: t0 + 10,
+      metadata: %{}
+    })
+
+    Ingestor.ingest_event(%{
+      trace_id: "trace-abc",
+      span_id: "span-child",
+      parent_span_id: "span-root",
+      agent_id: "weather-agent-1",
+      type: :stop,
+      event_name: "jido.ai.tool.execute.stop",
+      timestamp_ms: t0 + 30,
+      metadata: %{}
+    })
+
+    Ingestor.ingest_event(%{
+      trace_id: "trace-abc",
+      span_id: "span-root",
+      parent_span_id: nil,
+      agent_id: "weather-agent-1",
+      type: :stop,
+      event_name: "jido.agent.cmd.stop",
+      timestamp_ms: t0 + 40,
+      metadata: %{}
+    })
+
+    Process.sleep(40)
+
+    assert {:ok, trace} = Tracing.get_trace("trace-abc")
+    assert trace.status == "ok"
+    assert trace.agent_id == "weather-agent-1"
+    assert is_integer(trace.duration_ms)
+    assert trace.duration_ms >= 40
+
+    spans = Tracing.list_trace_spans("trace-abc")
+    assert length(spans) == 2
+
+    root = Enum.find(spans, &(&1.span_id == "span-root"))
+    child = Enum.find(spans, &(&1.span_id == "span-child"))
+
+    assert root.depth == 0
+    assert child.depth == 1
+    assert child.parent_span_id == "span-root"
+
+    events = Tracing.list_trace_events("trace-abc", order: :asc, limit: 10)
+    assert length(events) == 4
+    assert Enum.map(events, & &1.seq) == [1, 2, 3, 4]
+  end
+
+  defp clear_table(table) do
+    if :ets.whereis(table) != :undefined do
+      :ets.delete_all_objects(table)
+    end
+  end
+end

--- a/test/jido_studio/persistence_ets_test.exs
+++ b/test/jido_studio/persistence_ets_test.exs
@@ -1,0 +1,66 @@
+defmodule JidoStudio.PersistenceETSTest do
+  use ExUnit.Case, async: false
+
+  alias JidoStudio.Persistence
+
+  setup do
+    old_persistence = Application.get_env(:jido_studio, :persistence)
+
+    Application.put_env(:jido_studio, :persistence,
+      adapter: JidoStudio.Persistence.ETS,
+      opts: [event_retention: 50]
+    )
+
+    if pid = Process.whereis(JidoStudio.Persistence.ETS) do
+      GenServer.stop(pid)
+    end
+
+    clear_table(:jido_studio_persistence_docs)
+    clear_table(:jido_studio_persistence_events)
+    clear_table(:jido_studio_persistence_event_seq)
+
+    on_exit(fn ->
+      Application.put_env(:jido_studio, :persistence, old_persistence)
+    end)
+
+    :ok
+  end
+
+  test "put/get/list/delete doc lifecycle" do
+    assert :ok =
+             Persistence.put_doc("traces", "trace-1", %{status: "running", agent_id: "agent-1"})
+
+    assert :ok = Persistence.put_doc("traces", "trace-2", %{status: "ok", agent_id: "agent-2"})
+
+    assert {:ok, doc} = Persistence.get_doc("traces", "trace-1")
+    assert doc.id == "trace-1"
+    assert doc.status == "running"
+
+    docs = Persistence.list_docs("traces", order: :asc, sort_by: :id, limit: 10)
+    assert Enum.map(docs, & &1.id) |> Enum.sort() == ["trace-1", "trace-2"]
+
+    assert :ok = Persistence.delete_doc("traces", "trace-2")
+    assert :not_found = Persistence.get_doc("traces", "trace-2")
+  end
+
+  test "append_event/read_events keeps stream ordering" do
+    assert {:ok, %{seq: 1}} = Persistence.append_event("trace:trace-1", %{type: :start, step: 1})
+    assert {:ok, %{seq: 2}} = Persistence.append_event("trace:trace-1", %{type: :stop, step: 2})
+    assert {:ok, %{seq: 1}} = Persistence.append_event("trace:trace-2", %{type: :start, step: 1})
+
+    events_asc = Persistence.read_events("trace:trace-1", order: :asc, limit: 10)
+    assert Enum.map(events_asc, & &1.seq) == [1, 2]
+
+    events_desc = Persistence.read_events("trace:trace-1", order: :desc, limit: 10)
+    assert Enum.map(events_desc, & &1.seq) == [2, 1]
+
+    assert length(Persistence.read_events("trace:trace-1", after_seq: 1)) == 1
+    assert length(Persistence.read_events("trace:trace-1", before_seq: 2)) == 1
+  end
+
+  defp clear_table(table) do
+    if :ets.whereis(table) != :undefined do
+      :ets.delete_all_objects(table)
+    end
+  end
+end

--- a/test/jido_studio/threads_explorer_test.exs
+++ b/test/jido_studio/threads_explorer_test.exs
@@ -1,0 +1,67 @@
+defmodule JidoStudio.ThreadsExplorerTest do
+  use ExUnit.Case, async: false
+
+  alias JidoStudio.Chat.Session
+  alias JidoStudio.Threads
+  alias JidoStudio.Threads.Manager
+
+  setup do
+    table = String.to_atom("jido_studio_threads_explorer_#{System.unique_integer([:positive])}")
+
+    old_storage = Application.get_env(:jido_studio, :thread_storage)
+    old_mode = Application.get_env(:jido_studio, :thread_storage_mode)
+    old_enabled = Application.get_env(:jido_studio, :thread_persistence)
+
+    Application.put_env(:jido_studio, :thread_storage, {Jido.Storage.ETS, table: table})
+    Application.put_env(:jido_studio, :thread_storage_mode, :studio)
+    Application.put_env(:jido_studio, :thread_persistence, true)
+
+    ensure_manager_started()
+
+    on_exit(fn ->
+      Application.put_env(:jido_studio, :thread_storage, old_storage)
+      Application.put_env(:jido_studio, :thread_storage_mode, old_mode)
+      Application.put_env(:jido_studio, :thread_persistence, old_enabled)
+
+      for suffix <- [:checkpoints, :threads, :thread_meta] do
+        table_name = String.to_atom("#{table}_#{suffix}")
+
+        if :ets.whereis(table_name) != :undefined do
+          :ets.delete(table_name)
+        end
+      end
+    end)
+
+    {:ok, table: table}
+  end
+
+  test "list_threads and get_thread expose persisted entries" do
+    state = Session.with_initial_thread("Weather Debug")
+    {state, pending_id} = Session.append_user_turn(state, "hello")
+    state = Session.resolve_assistant_reply(state, pending_id, "world")
+
+    assert :ok = Manager.save_workspace("weather", "inst-thread-1", state)
+
+    threads = Threads.list_threads()
+
+    assert [%{thread_id: thread_id, agent_slug: "weather", agent_id: "inst-thread-1"} | _] =
+             Enum.filter(threads, &(&1.agent_id == "inst-thread-1"))
+
+    assert {:ok, payload} = Threads.get_thread("weather", "inst-thread-1", thread_id)
+
+    assert payload.thread.thread_id == thread_id
+    assert payload.thread.entry_count >= 2
+    assert length(payload.entries) >= 2
+    assert Enum.any?(payload.entries, &is_binary(&1.payload_preview))
+  end
+
+  defp ensure_manager_started do
+    case Process.whereis(Manager) do
+      nil ->
+        {:ok, _pid} = Manager.start_link([])
+
+      _pid ->
+        :ok
+    end
+  end
+end

--- a/test/jido_studio/threads_manager_test.exs
+++ b/test/jido_studio/threads_manager_test.exs
@@ -89,7 +89,14 @@ defmodule JidoStudio.ThreadsManagerTest do
       payload: %{
         event: :upsert_message,
         message_id: "external_msg",
-        message: %{id: "external_msg", role: :assistant, content: "external", state: :complete, tool_events: [], at: System.system_time(:millisecond)}
+        message: %{
+          id: "external_msg",
+          role: :assistant,
+          content: "external",
+          state: :complete,
+          tool_events: [],
+          at: System.system_time(:millisecond)
+        }
       },
       refs: %{}
     }
@@ -97,7 +104,9 @@ defmodule JidoStudio.ThreadsManagerTest do
     assert {:ok, _thread} = Storage.append_thread(thread_key, [external_entry], expected_rev: rev)
 
     {updated_state, updated_pending_id} = Session.append_user_turn(state, "second")
-    updated_state = Session.resolve_assistant_reply(updated_state, updated_pending_id, "second done")
+
+    updated_state =
+      Session.resolve_assistant_reply(updated_state, updated_pending_id, "second done")
 
     assert :ok = Manager.save_workspace("weather", "instance-c", updated_state)
 

--- a/test/jido_studio/threads_storage_test.exs
+++ b/test/jido_studio/threads_storage_test.exs
@@ -43,8 +43,38 @@ defmodule JidoStudio.ThreadsStorageTest do
   test "thread append/load keeps order and detects conflicts", %{table: _table} do
     thread_key = Storage.thread_key("weather", "inst-1", "thread-1")
 
-    entry_1 = %Entry{id: nil, seq: 0, at: 0, kind: :message, payload: %{event: :upsert_message, message_id: "m1", message: %{id: "m1", role: :user, content: "hi", state: :complete, tool_events: [], at: 1}}, refs: %{}}
-    entry_2 = %Entry{id: nil, seq: 0, at: 0, kind: :message, payload: %{event: :upsert_message, message_id: "m2", message: %{id: "m2", role: :assistant, content: "hello", state: :complete, tool_events: [], at: 2}}, refs: %{}}
+    entry_1 = %Entry{
+      id: nil,
+      seq: 0,
+      at: 0,
+      kind: :message,
+      payload: %{
+        event: :upsert_message,
+        message_id: "m1",
+        message: %{id: "m1", role: :user, content: "hi", state: :complete, tool_events: [], at: 1}
+      },
+      refs: %{}
+    }
+
+    entry_2 = %Entry{
+      id: nil,
+      seq: 0,
+      at: 0,
+      kind: :message,
+      payload: %{
+        event: :upsert_message,
+        message_id: "m2",
+        message: %{
+          id: "m2",
+          role: :assistant,
+          content: "hello",
+          state: :complete,
+          tool_events: [],
+          at: 2
+        }
+      },
+      refs: %{}
+    }
 
     assert {:ok, thread} = Storage.append_thread(thread_key, [entry_1], expected_rev: 0)
     assert thread.rev == 1


### PR DESCRIPTION
## Summary\n- add simple persistence abstraction with ETS default and optional Ecto adapter\n- add ingestion + trace/span materialization for observability MVP\n- add Traces list/detail explorer, Threads explorer, and Discovery registry pages\n- add live event search/tail improvements in Agents view\n- add migration template and tests for persistence/ingestor/threads explorer\n\n## Validation\n- mix compile --warnings-as-errors\n- mix test