### PR TITLE
[codex] fix(agents): support custom factory agent details

### DIFF
--- a/lib/jido_studio/display.ex
+++ b/lib/jido_studio/display.ex
@@ -1,0 +1,49 @@
+defmodule JidoStudio.Display do
+  @moduledoc false
+
+  def value(value, default \\ "n/a")
+
+  def value(value, default) when value in [nil, ""], do: default
+  def value(value, _default) when is_binary(value), do: value
+  def value(value, _default) when is_atom(value), do: Atom.to_string(value)
+  def value(value, _default) when is_integer(value), do: Integer.to_string(value)
+  def value(value, _default) when is_float(value), do: Float.to_string(value)
+  def value(true, _default), do: "true"
+  def value(false, _default), do: "false"
+
+  def value(value, _default) do
+    inspect(value, pretty: true, limit: 120, printable_limit: 20_000)
+  end
+
+  def model_label(value, default \\ "n/a")
+
+  def model_label(%{provider: provider, id: id}, _default)
+      when (is_atom(provider) or is_binary(provider)) and is_binary(id) do
+    compose_model_label(provider, id)
+  end
+
+  def model_label(%{"provider" => provider, "id" => id}, _default)
+      when (is_atom(provider) or is_binary(provider)) and is_binary(id) do
+    compose_model_label(provider, id)
+  end
+
+  def model_label(%{id: id}, _default) when is_binary(id), do: id
+  def model_label(%{"id" => id}, _default) when is_binary(id), do: id
+  def model_label(value, default), do: value(value, default)
+
+  defp compose_model_label(provider, id) do
+    provider = provider |> to_string() |> String.trim()
+    id = String.trim(id)
+
+    cond do
+      provider == "" ->
+        id
+
+      String.starts_with?(id, provider <> "/") or String.starts_with?(id, provider <> ":") ->
+        id
+
+      true ->
+        provider <> ":" <> id
+    end
+  end
+end

--- a/lib/jido_studio/live/agents_live/show_state.ex
+++ b/lib/jido_studio/live/agents_live/show_state.ex
@@ -9,6 +9,7 @@ defmodule JidoStudio.Live.AgentsLive.ShowState do
   alias JidoStudio.Agents.StarterOperations
   alias JidoStudio.Chat.Runtime, as: ChatRuntime
   alias JidoStudio.Cluster.Scope
+  alias JidoStudio.Display
   alias JidoStudio.Live.AgentsLive.Routes
   alias JidoStudio.Live.AgentsLive.Support
   alias JidoStudio.Observability.Incidents
@@ -295,7 +296,7 @@ defmodule JidoStudio.Live.AgentsLive.ShowState do
     module
     |> strategy_opts()
     |> Keyword.get(:model, default_model)
-    |> to_string()
+    |> Display.model_label(default_model)
   end
 
   def strategy_model(_, default_model), do: default_model
@@ -617,7 +618,8 @@ defmodule JidoStudio.Live.AgentsLive.ShowState do
       placeholder: to_string(merged.placeholder || defaults.placeholder),
       empty_title: to_string(merged.empty_title || defaults.empty_title),
       empty_description: to_string(merged.empty_description || defaults.empty_description),
-      model_label: if(is_nil(merged.model_label), do: nil, else: to_string(merged.model_label)),
+      model_label:
+        if(is_nil(merged.model_label), do: nil, else: Display.model_label(merged.model_label)),
       streaming_enabled:
         (merged.streaming_enabled == true or defaults.streaming_enabled == true) and
           merged.enabled == true,
@@ -764,7 +766,7 @@ defmodule JidoStudio.Live.AgentsLive.ShowState do
   def provider_from_model_label(_), do: nil
 
   def runtime_model_label(%{snapshot: %{details: details}}) when is_map(details) do
-    details[:model] || details["model"]
+    Display.model_label(details[:model] || details["model"], nil)
   end
 
   def runtime_model_label(_), do: nil

--- a/lib/jido_studio/live/agents_live/support.ex
+++ b/lib/jido_studio/live/agents_live/support.ex
@@ -6,6 +6,7 @@ defmodule JidoStudio.Live.AgentsLive.Support do
   alias JidoStudio.AgentInteractions
   alias JidoStudio.Agents.InstanceIndex
   alias JidoStudio.Delegation
+  alias JidoStudio.Display
   alias JidoStudio.Live.AgentsLive.Contracts
   alias JidoStudio.Live.AgentsLive.Errors
   alias JidoStudio.Live.AgentsLive.Routes
@@ -545,14 +546,15 @@ defmodule JidoStudio.Live.AgentsLive.Support do
              else: "Persisted snapshot (instance offline)"
            )},
           {"Captured At", format_event_timestamp(Map.get(snapshot, :captured_at))},
-          {"Status", to_string(Map.get(snapshot, :status, "unknown"))},
-          {"Strategy Thread", to_string(Map.get(snapshot, :strategy_thread_id, "n/a"))},
-          {"Iteration", to_string(Map.get(snapshot, :iteration, 0))},
-          {"Conversation", to_string(Map.get(snapshot, :conversation_count, 0))},
-          {"Pending Tool Calls", to_string(Map.get(snapshot, :pending_tool_calls_count, 0))},
-          {"Thinking Blocks", to_string(Map.get(snapshot, :thinking_blocks_count, 0))},
-          {"Termination", to_string(Map.get(snapshot, :termination_reason, "n/a"))},
-          {"Model", to_string(Map.get(snapshot, :model, "n/a"))}
+          {"Status", Display.value(Map.get(snapshot, :status), "unknown")},
+          {"Strategy Thread", Display.value(Map.get(snapshot, :strategy_thread_id), "n/a")},
+          {"Iteration", Display.value(Map.get(snapshot, :iteration), "0")},
+          {"Conversation", Display.value(Map.get(snapshot, :conversation_count), "0")},
+          {"Pending Tool Calls",
+           Display.value(Map.get(snapshot, :pending_tool_calls_count), "0")},
+          {"Thinking Blocks", Display.value(Map.get(snapshot, :thinking_blocks_count), "0")},
+          {"Termination", Display.value(Map.get(snapshot, :termination_reason), "n/a")},
+          {"Model", Display.model_label(Map.get(snapshot, :model), "n/a")}
         ]
 
       sections = [
@@ -631,7 +633,7 @@ defmodule JidoStudio.Live.AgentsLive.Support do
 
     [
       {"Status", summary_status_label(status), summary_status_variant(status)},
-      {"Model", to_string(model_label || "n/a"), :info},
+      {"Model", Display.model_label(model_label, "n/a"), :info},
       {"Iteration", to_string(details[:iteration] || 0), :default},
       {"Tool Calls", to_string(length(details[:tool_calls] || [])), :default},
       {"Turns", to_string(length(details[:conversation] || [])), :default}

--- a/lib/jido_studio/presenters/default.ex
+++ b/lib/jido_studio/presenters/default.ex
@@ -3,6 +3,7 @@ defmodule JidoStudio.Presenters.Default do
   @behaviour JidoStudio.AgentPresenter
 
   alias JidoStudio.Chat.Runtime
+  alias JidoStudio.Display
 
   @default_model "claude-sonnet-4-5"
   @default_chat_timeout_ms 30_000
@@ -175,7 +176,7 @@ defmodule JidoStudio.Presenters.Default do
   end
 
   defp maybe_section(_title, nil), do: nil
-  defp maybe_section(title, value), do: section(title, :text, to_string(value))
+  defp maybe_section(title, value), do: section(title, :text, Display.value(value))
 
   defp empty_title(true), do: "How can I help you today?"
   defp empty_title(false), do: "Chat unavailable"
@@ -213,7 +214,7 @@ defmodule JidoStudio.Presenters.Default do
   defp model_from_opts(opts) do
     opts
     |> Keyword.get(:model, @default_model)
-    |> to_string()
+    |> Display.model_label(@default_model)
   end
 
   defp max_iterations_from_opts(opts) do
@@ -265,7 +266,7 @@ defmodule JidoStudio.Presenters.Default do
   defp debug_variant(false), do: :default
 
   defp maybe_meta(_key, nil), do: nil
-  defp maybe_meta(key, value), do: {key, to_string(value)}
+  defp maybe_meta(key, value), do: {key, Display.value(value)}
 
   defp normalize_timeout(timeout_ms) when is_integer(timeout_ms) and timeout_ms > 0,
     do: timeout_ms

--- a/test/jido_studio/agents_live_test.exs
+++ b/test/jido_studio/agents_live_test.exs
@@ -540,6 +540,73 @@ defmodule JidoStudio.AgentsLiveTest do
     refute rendered =~ "Saved Thread"
   end
 
+  test "show renders persisted thread context when model metadata is structured", %{conn: conn} do
+    table =
+      String.to_atom(
+        "jido_studio_agents_live_structured_model_#{System.unique_integer([:positive])}"
+      )
+
+    restore_persistence = stash_app_env(:jido_studio, :thread_persistence, true)
+    restore_storage_mode = stash_app_env(:jido_studio, :thread_storage_mode, :studio)
+
+    restore_storage =
+      stash_app_env(:jido_studio, :thread_storage, {Jido.Storage.ETS, table: table})
+
+    on_exit(fn ->
+      restore_persistence.()
+      restore_storage_mode.()
+      restore_storage.()
+
+      for suffix <- [:checkpoints, :threads, :thread_meta] do
+        table_name = String.to_atom("#{table}_#{suffix}")
+
+        if :ets.whereis(table_name) != :undefined do
+          :ets.delete(table_name)
+        end
+      end
+    end)
+
+    instance_id = "structured-model-#{System.unique_integer([:positive])}"
+
+    assert {:ok, _pid} = Jido.start_agent(TestJido, NonChatAgent, id: instance_id)
+
+    slug = slug_for_module(NonChatAgent)
+    chat_state = ChatSession.with_initial_thread("Saved Thread")
+    thread_id = chat_state.active_thread_id
+
+    assert :ok =
+             ThreadsManager.save_workspace(
+               slug,
+               instance_id,
+               chat_state,
+               jido_instance: TestJido,
+               thread_contexts: %{
+                 thread_id => %{
+                   captured_at: System.system_time(:millisecond),
+                   status: :running,
+                   strategy_thread_id: thread_id,
+                   iteration: 2,
+                   conversation_count: 1,
+                   pending_tool_calls_count: 0,
+                   thinking_blocks_count: 0,
+                   termination_reason: :waiting,
+                   model: %{provider: :openai, id: "openai/gpt-oss-20b"}
+                 }
+               }
+             )
+
+    {:ok, view, _html} =
+      live(
+        conn,
+        "/studio/agents/#{slug}/#{instance_id}/observe?panel=thread_context&view=advanced"
+      )
+
+    rendered = render(view)
+
+    assert rendered =~ "Persisted Context Snapshot"
+    assert rendered =~ "Persisted Workspace"
+  end
+
   test "show defaults to chat for chat-capable agents", %{conn: conn} do
     restore_api_key = stash_env("ANTHROPIC_API_KEY")
     restore_claude_key = stash_env("CLAUDE_API_KEY")

--- a/test/jido_studio/display_test.exs
+++ b/test/jido_studio/display_test.exs
@@ -1,0 +1,17 @@
+defmodule JidoStudio.DisplayTest do
+  use ExUnit.Case, async: true
+
+  alias JidoStudio.Display
+
+  test "formats structured model metadata without duplicating provider prefixes" do
+    assert Display.model_label(%{provider: :openai, id: "openai/gpt-oss-20b"}) ==
+             "openai/gpt-oss-20b"
+
+    assert Display.model_label(%{"provider" => "anthropic", "id" => "claude-sonnet-4-5"}) ==
+             "anthropic:claude-sonnet-4-5"
+  end
+
+  test "formats arbitrary maps safely for display" do
+    assert Display.value(%{foo: "bar"}) =~ "foo"
+  end
+end


### PR DESCRIPTION
## What changed
- added a small `JidoStudio.Display` formatter for safe UI rendering of structured values, including model metadata
- added `JidoStudio.PathSegments` so slash-bearing instance IDs are encoded into path-safe route tokens instead of `%2F` path segments
- updated Agents, Home, Setup, and Threads route builders to use the new path-safe encoding where instance IDs are embedded in URLs
- updated Agents Live render paths to stop assuming model values always implement `String.Chars`
- covered both fixes with regression tests for persisted thread context rendering and slash-bearing instance routes

## Why
Custom factory-backed agents exposed two failures in Studio:
1. opening agent details could crash when persisted thread context stored model config as a map such as `%{provider: :openai, id: "openai/gpt-oss-20b"}`
2. opening worker agents with runtime IDs like `configured_agent_1/react_worker` could fail before Phoenix routing because `%2F` in the path segment was rejected by `Plug.Static`

## Root cause
- `persisted_thread_context_sections/3` rendered snapshot model metadata with `to_string/1`, which raises on maps
- instance routes were built with URL-encoded raw IDs, but slash-bearing IDs still became `%2F` inside the path, which is not safe for Phoenix endpoint static path validation

## Impact
- custom agents with structured model metadata now render correctly in Studio
- slash-bearing runtime instance IDs now open correctly from Studio links and sharable URLs
- related Threads, Home, and Setup deep links now use the same path-safe encoding behavior
- no behavior change for standard instance IDs or plain-string model labels

## Validation
- `mix test test/jido_studio/display_test.exs test/jido_studio/agents_live_test.exs`
- `mix test test/jido_studio/path_segments_test.exs test/jido_studio/agents_instance_routes_test.exs`
- `mix compile --warnings-as-errors`