### PR TITLE
[codex] fix(routes): support slash-bearing instance ids

### DIFF
--- a/lib/jido_studio/live/agents_live/routes.ex
+++ b/lib/jido_studio/live/agents_live/routes.ex
@@ -3,6 +3,7 @@ defmodule JidoStudio.Live.AgentsLive.Routes do
 
   alias JidoStudio.Cluster.Scope
   alias JidoStudio.Live.AgentsLive.Contracts
+  alias JidoStudio.PathSegments
 
   def workbench_section_path(prefix, agent, instance_id, section, view_mode \\ nil) do
     section =
@@ -10,7 +11,7 @@ defmodule JidoStudio.Live.AgentsLive.Routes do
       |> Contracts.parse_instance_section()
       |> Contracts.section_query_value()
 
-    path = "#{prefix}/agents/#{agent.slug}/#{URI.encode_www_form(instance_id)}/#{section}"
+    path = "#{prefix}/agents/#{agent.slug}/#{PathSegments.encode(instance_id)}/#{section}"
 
     with_view =
       case Contracts.parse_instance_view_mode_param(view_mode) do

--- a/lib/jido_studio/live/agents_live/show_state.ex
+++ b/lib/jido_studio/live/agents_live/show_state.ex
@@ -13,13 +13,14 @@ defmodule JidoStudio.Live.AgentsLive.ShowState do
   alias JidoStudio.Live.AgentsLive.Routes
   alias JidoStudio.Live.AgentsLive.Support
   alias JidoStudio.Observability.Incidents
+  alias JidoStudio.PathSegments
   alias JidoStudio.Presenters.Default
 
   @default_model "claude-sonnet-4-5"
 
   def apply_show(socket, slug, params, opts \\ []) do
     jido_instance = socket.assigns[:jido_instance]
-    requested_instance_id = Map.get(params, "instance_id")
+    requested_instance_id = PathSegments.decode(Map.get(params, "instance_id"))
     start_modal_requested? = start_modal_requested?(params)
     requested_view_mode = Support.parse_instance_view_mode_param(Map.get(params, "view"))
     requested_workbench_tab = Support.requested_workbench_tab(params)
@@ -457,7 +458,7 @@ defmodule JidoStudio.Live.AgentsLive.ShowState do
 
   def active_instance_path(prefix, %{agent_slug: slug, instance_id: instance_id})
       when is_binary(prefix) and is_binary(slug) and is_binary(instance_id) do
-    scoped_path("#{prefix}/agents/#{slug}/#{URI.encode_www_form(instance_id)}/play")
+    scoped_path("#{prefix}/agents/#{slug}/#{PathSegments.encode(instance_id)}/play")
   end
 
   def active_instance_path(_prefix, _row), do: nil

--- a/lib/jido_studio/live/home_live.ex
+++ b/lib/jido_studio/live/home_live.ex
@@ -12,6 +12,7 @@ defmodule JidoStudio.HomeLive do
   alias JidoStudio.Live.HomeLive.State, as: HomeState
   alias JidoStudio.Naming
   alias JidoStudio.Observability.Incidents
+  alias JidoStudio.PathSegments
   alias JidoStudio.ProductMetrics
   alias JidoStudio.Setup
   alias JidoStudio.Setup.Helpers
@@ -613,7 +614,7 @@ defmodule JidoStudio.HomeLive do
 
       instance_id ->
         ScopeQuery.with_scope_query(
-          "#{prefix}/agents/#{slug}/#{URI.encode_www_form(instance_id)}",
+          "#{prefix}/agents/#{slug}/#{PathSegments.encode(instance_id)}",
           runtime_key,
           node_param
         )

--- a/lib/jido_studio/live/threads_live.ex
+++ b/lib/jido_studio/live/threads_live.ex
@@ -5,6 +5,7 @@ defmodule JidoStudio.ThreadsLive do
   import JidoStudio.Components
 
   alias JidoStudio.Cluster.Scope
+  alias JidoStudio.PathSegments
   alias JidoStudio.Threads
 
   @impl true
@@ -280,11 +281,11 @@ defmodule JidoStudio.ThreadsLive do
     base =
       prefix <>
         "/threads/" <>
-        URI.encode_www_form(thread.agent_slug) <>
+        PathSegments.encode(thread.agent_slug) <>
         "/" <>
-        URI.encode_www_form(thread.instance_id) <>
+        PathSegments.encode(thread.instance_id) <>
         "/" <>
-        URI.encode_www_form(thread.thread_id)
+        PathSegments.encode(thread.thread_id)
 
     if query == "" do
       Scope.with_scope_query(base, Scope.current_node_param())
@@ -309,7 +310,7 @@ defmodule JidoStudio.ThreadsLive do
     )
   end
 
-  defp decode_segment(value) when is_binary(value), do: URI.decode_www_form(value)
+  defp decode_segment(value) when is_binary(value), do: PathSegments.decode(value)
   defp decode_segment(_), do: ""
 
   defp format_timestamp(ts) when is_integer(ts) and ts > 0 do

--- a/lib/jido_studio/path_segments.ex
+++ b/lib/jido_studio/path_segments.ex
@@ -1,0 +1,31 @@
+defmodule JidoStudio.PathSegments do
+  @moduledoc false
+
+  @opaque_prefix "b64-"
+
+  def encode(value) when is_binary(value) do
+    if String.contains?(value, "/") do
+      @opaque_prefix <> Base.url_encode64(value, padding: false)
+    else
+      URI.encode(value, &URI.char_unreserved?/1)
+    end
+  end
+
+  def encode(value), do: value
+
+  def decode(value) when is_binary(value) do
+    if String.starts_with?(value, @opaque_prefix) do
+      value
+      |> String.replace_prefix(@opaque_prefix, "")
+      |> Base.url_decode64(padding: false)
+      |> case do
+        {:ok, decoded} -> decoded
+        :error -> URI.decode(value)
+      end
+    else
+      URI.decode(value)
+    end
+  end
+
+  def decode(value), do: value
+end

--- a/lib/jido_studio/setup.ex
+++ b/lib/jido_studio/setup.ex
@@ -3,6 +3,7 @@ defmodule JidoStudio.Setup do
 
   alias JidoStudio.AgentRegistry
   alias JidoStudio.Cluster.RPC
+  alias JidoStudio.PathSegments
   alias JidoStudio.ScopeQuery
   alias JidoStudio.Setup.Profiles
   alias JidoStudio.Threads.Storage, as: ThreadsStorage
@@ -413,7 +414,7 @@ defmodule JidoStudio.Setup do
           |> Enum.find_value(&Map.get(&1, :id))
 
         if is_binary(slug) and is_binary(instance_id) do
-          "#{prefix}/agents/#{slug}/#{URI.encode_www_form(instance_id)}"
+          "#{prefix}/agents/#{slug}/#{PathSegments.encode(instance_id)}"
         end
       end)
 

--- a/test/jido_studio/agents_instance_routes_test.exs
+++ b/test/jido_studio/agents_instance_routes_test.exs
@@ -2,6 +2,7 @@ defmodule JidoStudio.AgentsInstanceRoutesTest do
   use JidoStudio.ConnCase, async: false
 
   alias JidoStudio.AgentRegistry
+  alias JidoStudio.PathSegments
   alias JidoStudio.TestJido
 
   setup do
@@ -63,6 +64,28 @@ defmodule JidoStudio.AgentsInstanceRoutesTest do
     assert has_element?(view, ".js-instance-menu-tab.is-active", "Middleware")
     assert has_element?(view, "a[href*='/play'][href*='node=all']")
     assert has_element?(view, "a[href*='/observe'][href*='node=all']")
+  end
+
+  test "slash-bearing instance ids use path-safe routes", %{conn: conn} do
+    instance_id = "configured_agent_1/react_worker"
+
+    assert {:ok, _pid} =
+             Jido.start_agent(TestJido, Jido.AI.Examples.CalculatorAgent, id: instance_id)
+
+    slug = slug_for_module(Jido.AI.Examples.CalculatorAgent)
+    encoded_instance_id = PathSegments.encode(instance_id)
+
+    refute encoded_instance_id =~ "/"
+    refute encoded_instance_id =~ "%2F"
+
+    {:ok, _view, html} = live(conn, "/studio/agents")
+
+    assert html =~ "/studio/agents/#{slug}/#{encoded_instance_id}/play"
+
+    {:ok, view, _html} =
+      live(conn, "/studio/agents/#{slug}/#{encoded_instance_id}/play?node=all")
+
+    assert render(view) =~ "Basic View"
   end
 
   defp slug_for_module(module) do

--- a/test/jido_studio/path_segments_test.exs
+++ b/test/jido_studio/path_segments_test.exs
@@ -1,0 +1,22 @@
+defmodule JidoStudio.PathSegmentsTest do
+  use ExUnit.Case, async: true
+
+  alias JidoStudio.PathSegments
+
+  test "round trips standard path segments" do
+    value = "configured_agent_1"
+
+    assert value
+           |> PathSegments.encode()
+           |> PathSegments.decode() == value
+  end
+
+  test "encodes slash-bearing values as opaque path-safe tokens" do
+    value = "configured_agent_1/react_worker"
+    encoded = PathSegments.encode(value)
+
+    refute encoded =~ "/"
+    refute encoded =~ "%2F"
+    assert PathSegments.decode(encoded) == value
+  end
+end


### PR DESCRIPTION
## What changed
- added `JidoStudio.PathSegments` to encode slash-bearing route values into path-safe tokens
- updated Agents route builders and lookups so worker instance IDs like `configured_agent_1/react_worker` no longer end up in URLs as `%2F`
- updated Home, Setup, and Threads links that embed instance IDs so they use the same path-safe encoding
- added regression coverage for the path codec and for opening slash-bearing instance IDs from the Agents page

## Why
Studio could list worker agents spawned from a factory module, but opening them failed when the runtime instance ID contained a slash.

## Root cause
The route helpers embedded raw instance IDs into the path with URL encoding. That produced `%2F` inside a path segment, and `Plug.Static` rejected the request before Phoenix routing because encoded slashes are not valid static path segments.

## Impact
- slash-bearing worker/runtime instance IDs now open correctly from Studio
- sharable instance links use opaque, path-safe route tokens instead of unsafe `%2F` segments
- related deep links from Home, Setup, and Threads now follow the same behavior

## Validation
- `mix test test/jido_studio/path_segments_test.exs test/jido_studio/agents_instance_routes_test.exs`
- `mix compile --warnings-as-errors`