### PR TITLE
ci: migrate github-actions workflows to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   ci:
     name: CI
-    uses: agentjido/github-actions/.github/workflows/jido-ci.yml@v4
+    uses: agentjido/github-actions/.github/workflows/jido-ci.yml@v5
     secrets: inherit
     with:
       otp_versions: '["27", "28"]'

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -18,4 +18,4 @@ permissions:
 jobs:
   review:
     name: Jido Review
-    uses: agentjido/github-actions/.github/workflows/jido-review.yml@v4
+    uses: agentjido/github-actions/.github/workflows/jido-review.yml@v5


### PR DESCRIPTION
Migrate reusable Jido workflow callers from the v4 compatibility channel to the v5 compatibility channel.

This updates only public `jido-*` reusable workflow refs in `.github/workflows/`.

Validation target: pull request CI should resolve `agentjido/github-actions@v5` and use the published v5.1.1 workflow platform resolver.