### PR TITLE
[codex] fix: clear Elixir 1.20 compile warnings

### DIFF
--- a/lib/jido_studio/agents/message_snapshot.ex
+++ b/lib/jido_studio/agents/message_snapshot.ex
@@ -61,23 +61,17 @@ defmodule JidoStudio.Agents.MessageSnapshot do
     |> Enum.reverse()
   end
 
-  defp thread_entries_from_status(_), do: []
-
   defp strategy_state(status) when is_map(status) do
     status
     |> field(:raw_state, %{})
     |> field(:__strategy__, %{})
   end
 
-  defp strategy_state(_), do: %{}
-
   defp snapshot_details(status) when is_map(status) do
     status
     |> field(:snapshot, %{})
     |> field(:details, %{})
   end
-
-  defp snapshot_details(_), do: %{}
 
   defp role(entry) when is_map(entry) do
     case field(entry, :role) do

--- a/lib/jido_studio/agents/payload_form.ex
+++ b/lib/jido_studio/agents/payload_form.ex
@@ -156,8 +156,6 @@ defmodule JidoStudio.Agents.PayloadForm do
     end
   end
 
-  defp field_definitions(_), do: {:error, "Complex schema requires raw JSON mode."}
-
   defp simple_type(field_schema) when is_map(field_schema) do
     type = field_schema[:type] || field_schema["type"]
 

--- a/lib/jido_studio/agents/runner.ex
+++ b/lib/jido_studio/agents/runner.ex
@@ -186,8 +186,6 @@ defmodule JidoStudio.Agents.Runner do
     end)
   end
 
-  defp ensure_atom_keys(other), do: other
-
   defp summarize_result(%{id: id, state: state}) do
     %{
       agent_id: normalize_optional_string(id),
@@ -229,8 +227,6 @@ defmodule JidoStudio.Agents.Runner do
     _ -> nil
   end
 
-  defp status_snapshot(_), do: nil
-
   defp safe_state_snapshot(pid) when is_pid(pid) do
     case Jido.AgentServer.state(pid) do
       {:ok, %{state: state}} when is_map(state) ->
@@ -247,8 +243,6 @@ defmodule JidoStudio.Agents.Runner do
   catch
     :exit, _ -> %{}
   end
-
-  defp safe_state_snapshot(_), do: %{}
 
   defp normalize_map(%{__struct__: _} = struct),
     do: struct |> Map.from_struct() |> normalize_map()
@@ -290,8 +284,6 @@ defmodule JidoStudio.Agents.Runner do
     )
   end
 
-  defp extract_trace_id(_), do: nil
-
   defp dispatch_mode(:async), do: :async
   defp dispatch_mode("async"), do: :async
   defp dispatch_mode(_), do: :sync
@@ -300,8 +292,6 @@ defmodule JidoStudio.Agents.Runner do
   defp normalize_timeout(_), do: AgentInteractions.runner_timeout_ms()
 
   defp normalize_signal_type(value) when is_binary(value), do: String.trim(value)
-  defp normalize_signal_type(value) when is_atom(value), do: Atom.to_string(value)
-  defp normalize_signal_type(_), do: "unknown.signal"
 
   defp normalize_source(value) when is_binary(value) do
     case String.trim(value) do

--- a/lib/jido_studio/agents/signal_catalog.ex
+++ b/lib/jido_studio/agents/signal_catalog.ex
@@ -133,10 +133,10 @@ defmodule JidoStudio.Agents.SignalCatalog do
     |> Enum.map(fn route ->
       source =
         case route do
-          {path, _target, _priority} when is_binary(path) ->
+          {path, _target, opts} when is_binary(path) and is_list(opts) ->
             if String.contains?(path, ".__schedule__."), do: :plugin_schedule, else: :plugin
 
-          {path, _target, opts} when is_binary(path) and is_list(opts) ->
+          {path, _target, _priority} when is_binary(path) ->
             if String.contains?(path, ".__schedule__."), do: :plugin_schedule, else: :plugin
 
           _ ->
@@ -318,8 +318,6 @@ defmodule JidoStudio.Agents.SignalCatalog do
   rescue
     _ -> []
   end
-
-  defp safe_strategy_opts(_), do: []
 
   defp normalize_signal_type(value) when is_binary(value) do
     case String.trim(value) do

--- a/lib/jido_studio/chat/runtime.ex
+++ b/lib/jido_studio/chat/runtime.ex
@@ -336,8 +336,6 @@ defmodule JidoStudio.Chat.Runtime do
     |> Map.get(:__strategy__, %{})
   end
 
-  defp strategy_state(_), do: %{}
-
   defp extract_tool_events(entries, since_entry_count) when is_list(entries) do
     scoped_entries = Enum.drop(entries, min(since_entry_count, length(entries)))
 

--- a/lib/jido_studio/cluster/collect.ex
+++ b/lib/jido_studio/cluster/collect.ex
@@ -18,7 +18,7 @@ defmodule JidoStudio.Cluster.Collect do
 
   defp collect_all(module, fun, args, rpc_fun) do
     case rpc_fun.(:all, module, fun, args) do
-      {:ok, results} when is_list(results) ->
+      {:ok, [%{ok?: _} | _] = results} ->
         results
         |> Enum.flat_map(fn
           %{ok?: true, value: items} when is_list(items) -> items

--- a/lib/jido_studio/diagnostics/timeline.ex
+++ b/lib/jido_studio/diagnostics/timeline.ex
@@ -122,7 +122,7 @@ defmodule JidoStudio.Diagnostics.Timeline do
     scope
     |> RPC.call(Tracing, :list_traces, [query_opts])
     |> case do
-      {:ok, node_results} when is_list(node_results) ->
+      {:ok, [%{ok?: _} | _] = node_results} ->
         node_results
         |> Enum.flat_map(fn
           %{ok?: true, node: node, value: value} when is_list(value) ->
@@ -190,8 +190,6 @@ defmodule JidoStudio.Diagnostics.Timeline do
     |> max(0.0)
     |> min(100.0)
   end
-
-  defp clamp_percentage(_), do: 0.0
 
   defp maybe_clear_critical(spans, true), do: spans
 

--- a/lib/jido_studio/display.ex
+++ b/lib/jido_studio/display.ex
@@ -4,12 +4,11 @@ defmodule JidoStudio.Display do
   def value(value, default \\ "n/a")
 
   def value(value, default) when value in [nil, ""], do: default
+  def value(value, _default) when is_boolean(value), do: to_string(value)
   def value(value, _default) when is_binary(value), do: value
   def value(value, _default) when is_atom(value), do: Atom.to_string(value)
   def value(value, _default) when is_integer(value), do: Integer.to_string(value)
   def value(value, _default) when is_float(value), do: Float.to_string(value)
-  def value(true, _default), do: "true"
-  def value(false, _default), do: "false"
 
   def value(value, _default) do
     inspect(value, pretty: true, limit: 120, printable_limit: 20_000)

--- a/lib/jido_studio/ingestor.ex
+++ b/lib/jido_studio/ingestor.ex
@@ -1271,8 +1271,6 @@ defmodule JidoStudio.Ingestor do
     |> Enum.take(-max_size)
   end
 
-  defp append_recent_item(items, _item, _max_size), do: List.wrap(items)
-
   defp safe_doc_segment(value) do
     value
     |> to_string()
@@ -1288,8 +1286,6 @@ defmodule JidoStudio.Ingestor do
       true -> []
     end
   end
-
-  defp middleware_chain(_), do: []
 
   defp event_timestamp(event) when is_map(event) do
     case event[:timestamp_ms] do

--- a/lib/jido_studio/live/agents_live/observability_state.ex
+++ b/lib/jido_studio/live/agents_live/observability_state.ex
@@ -71,9 +71,6 @@ defmodule JidoStudio.Live.AgentsLive.ObservabilityState do
           |> Map.get(:duration)
           |> duration_to_ms()
 
-        is_map(start_event) and is_map(stop_event) ->
-          (stop_event[:timestamp_ms] || 0) - (start_event[:timestamp_ms] || 0)
-
         true ->
           nil
       end

--- a/lib/jido_studio/live/agents_live/render/basic_instance_view.ex
+++ b/lib/jido_studio/live/agents_live/render/basic_instance_view.ex
@@ -473,9 +473,6 @@ defmodule JidoStudio.Live.AgentsLive.Render.BasicInstanceView do
     "Guided fields unavailable: #{reason} Switch to Raw JSON (Advanced) to continue."
   end
 
-  defp payload_form_message(_),
-    do: "Guided fields unavailable. Switch to Raw JSON (Advanced) to continue."
-
   defp schema_mode_button_class(true),
     do: "rounded bg-js-bg-elevated px-2.5 py-1.5 text-xs text-js-text"
 
@@ -517,7 +514,6 @@ defmodule JidoStudio.Live.AgentsLive.Render.BasicInstanceView do
   defp show_field_description?(_), do: false
 
   defp field_description(value) when is_binary(value), do: String.trim(value)
-  defp field_description(_), do: nil
 
   defp runner_guard_hint(true),
     do: "Inputs are confirmed. Any edit will require confirmation again."
@@ -680,8 +676,6 @@ defmodule JidoStudio.Live.AgentsLive.Render.BasicInstanceView do
     |> String.split("::", parts: 2)
     |> List.first()
   end
-
-  defp compact_signal_key(_), do: "unknown"
 
   defp scoped_path(path), do: ShowState.scoped_path(path)
 end

--- a/lib/jido_studio/live/catalog_live.ex
+++ b/lib/jido_studio/live/catalog_live.ex
@@ -240,15 +240,15 @@ defmodule JidoStudio.CatalogLive do
 
     results =
       case RPC.call(scope, Jido.Discovery, fun, args) do
-        {:ok, items} when is_list(items) ->
-          items
-
-        {:ok, node_results} when is_list(node_results) ->
+        {:ok, [%{ok?: _} | _] = node_results} ->
           node_results
           |> Enum.flat_map(fn
             %{ok?: true, value: items} when is_list(items) -> items
             _ -> []
           end)
+
+        {:ok, items} when is_list(items) ->
+          items
 
         _ ->
           []

--- a/lib/jido_studio/live/home_live.ex
+++ b/lib/jido_studio/live/home_live.ex
@@ -719,8 +719,6 @@ defmodule JidoStudio.HomeLive do
     end
   end
 
-  defp maybe_emit_next_step_links_telemetry(socket, _), do: socket
-
   defp normalize_starter_mode(value, fallback) when is_binary(value) do
     case String.trim(value) do
       "" -> fallback

--- a/lib/jido_studio/live_ops.ex
+++ b/lib/jido_studio/live_ops.ex
@@ -212,13 +212,8 @@ defmodule JidoStudio.LiveOps do
 
   @spec presence_available?() :: boolean()
   def presence_available? do
-    case presence_module() do
-      module when is_atom(module) ->
-        Code.ensure_loaded?(module) and function_exported?(module, :list, 1)
-
-      _ ->
-        false
-    end
+    module = presence_module()
+    Code.ensure_loaded?(module) and function_exported?(module, :list, 1)
   end
 
   @spec pubsub_name() :: atom()

--- a/lib/jido_studio/observability/correlation.ex
+++ b/lib/jido_studio/observability/correlation.ex
@@ -17,12 +17,12 @@ defmodule JidoStudio.Observability.Correlation do
     :incident_id
   ]
 
-  @type record :: map()
+  @type correlation_record :: map()
 
   @spec canonical_keys() :: [atom()]
   def canonical_keys, do: @canonical_keys
 
-  @spec normalize(record()) :: record()
+  @spec normalize(correlation_record()) :: correlation_record()
   def normalize(record) when is_map(record) do
     metadata = normalize_map(fetch(record, :metadata))
     scope = merged_scope(fetch(record, :scope), metadata)
@@ -118,7 +118,7 @@ defmodule JidoStudio.Observability.Correlation do
 
   def normalize(other), do: %{ts: now_ms(), incident_id: nil, raw: other}
 
-  @spec incident_id(record()) :: String.t() | nil
+  @spec incident_id(correlation_record()) :: String.t() | nil
   def incident_id(record) when is_map(record) do
     record
     |> normalize()
@@ -150,8 +150,6 @@ defmodule JidoStudio.Observability.Correlation do
         nil
     end
   end
-
-  defp incident_id_from(_), do: nil
 
   defp action_from_entity(entity_type, entity_id) do
     if normalize_optional_string(entity_type) in ["tool", "action"] do

--- a/lib/jido_studio/observability/incidents.ex
+++ b/lib/jido_studio/observability/incidents.ex
@@ -332,8 +332,6 @@ defmodule JidoStudio.Observability.Incidents do
     end
   end
 
-  defp next_status(_, _), do: "running"
-
   defp error_event?(event) when is_map(event) do
     normalize_optional_string(event[:status]) == "error" or
       normalize_optional_string(event[:type]) == "exception" or

--- a/lib/jido_studio/observability/workflows.ex
+++ b/lib/jido_studio/observability/workflows.ex
@@ -155,8 +155,6 @@ defmodule JidoStudio.Observability.Workflows do
     end
   end
 
-  defp duration(_), do: nil
-
   defp run_sort_key(run) when is_map(run) do
     run[:last_event_at] || run[:updated_at] || run[:started_at] || 0
   end

--- a/lib/jido_studio/persistence.ex
+++ b/lib/jido_studio/persistence.ex
@@ -126,6 +126,4 @@ defmodule JidoStudio.Persistence do
       function_exported?(adapter, :append_event, 3) and
       function_exported?(adapter, :read_events, 2)
   end
-
-  defp valid_adapter?(_), do: false
 end

--- a/lib/jido_studio/product_metrics.ex
+++ b/lib/jido_studio/product_metrics.ex
@@ -157,12 +157,12 @@ defmodule JidoStudio.ProductMetrics do
     |> Telemetry.compact_metadata()
   end
 
-  defp normalize_metadata_value(value) when is_atom(value), do: Atom.to_string(value)
+  defp normalize_metadata_value(nil), do: nil
+  defp normalize_metadata_value(value) when is_boolean(value), do: value
   defp normalize_metadata_value(value) when is_binary(value), do: String.trim(value)
+  defp normalize_metadata_value(value) when is_atom(value), do: Atom.to_string(value)
   defp normalize_metadata_value(value) when is_integer(value), do: value
   defp normalize_metadata_value(value) when is_float(value), do: value
-  defp normalize_metadata_value(value) when is_boolean(value), do: value
-  defp normalize_metadata_value(nil), do: nil
   defp normalize_metadata_value(value), do: inspect(value)
 
   defp normalize_optional_string(value) when is_binary(value) do

--- a/lib/jido_studio/runtime_scope.ex
+++ b/lib/jido_studio/runtime_scope.ex
@@ -184,8 +184,6 @@ defmodule JidoStudio.RuntimeScope do
     |> Enum.map_join(" ", &capitalize/1)
   end
 
-  defp humanize_key(_), do: "Runtime"
-
   defp capitalize(""), do: ""
 
   defp capitalize(value) do

--- a/lib/jido_studio/setup/helpers.ex
+++ b/lib/jido_studio/setup/helpers.ex
@@ -87,6 +87,4 @@ defmodule JidoStudio.Setup.Helpers do
       _ -> "n/a"
     end
   end
-
-  defp storage_path(_), do: "n/a"
 end

--- a/lib/jido_studio/threads.ex
+++ b/lib/jido_studio/threads.ex
@@ -125,8 +125,6 @@ defmodule JidoStudio.Threads do
     end
   end
 
-  defp payload_preview(payload), do: inspect(payload, limit: 6, printable_limit: 800)
-
   defp trace_id_from(payload, refs) do
     refs[:trace_id] || refs["trace_id"] || payload[:trace_id] || payload["trace_id"] ||
       payload[:jido_trace_id] || payload["jido_trace_id"]

--- a/lib/jido_studio/threads/codec.ex
+++ b/lib/jido_studio/threads/codec.ex
@@ -346,7 +346,7 @@ defmodule JidoStudio.Threads.Codec do
       key = normalize_optional_binary(key)
       value = normalize_optional_binary(value)
 
-      if is_binary(key) and key != "" and is_binary(value) and value != "" do
+      if key != "" and is_binary(value) and value != "" do
         Map.put(acc, key, value)
       else
         acc

--- a/lib/jido_studio/trace_buffer.ex
+++ b/lib/jido_studio/trace_buffer.ex
@@ -465,8 +465,6 @@ defmodule JidoStudio.TraceBuffer do
     _ -> :ok
   end
 
-  defp broadcast_live_ops(_), do: :ok
-
   defp infer_entity_type(prefix) when is_list(prefix) do
     values = Enum.map(prefix, &to_string/1)
 
@@ -481,8 +479,6 @@ defmodule JidoStudio.TraceBuffer do
     end
   end
 
-  defp infer_entity_type(_), do: :other
-
   defp infer_internal?(prefix) when is_list(prefix) do
     values = Enum.map(prefix, &to_string/1)
 
@@ -490,8 +486,6 @@ defmodule JidoStudio.TraceBuffer do
       Enum.member?(values, "agent_server") or
       Enum.member?(values, "middleware")
   end
-
-  defp infer_internal?(_), do: false
 
   defp event_status(:exception), do: "error"
   defp event_status("exception"), do: "error"
@@ -521,8 +515,6 @@ defmodule JidoStudio.TraceBuffer do
     |> maybe_put_scope(:project_id, metadata[:project_id] || metadata["project_id"])
     |> maybe_put_scope(:user_id, metadata[:user_id] || metadata["user_id"])
   end
-
-  defp scope_from_metadata(_), do: %{}
 
   defp maybe_put_scope(scope, _key, nil), do: scope
   defp maybe_put_scope(scope, key, value), do: Map.put(scope, key, value)


### PR DESCRIPTION
## Summary

- Rename the observability correlation `record` type so it no longer collides with the Elixir built-in type.
- Remove unreachable private fallback clauses and redundant case/cond branches surfaced by Elixir 1.20 warning checks.
- Keep direct-list and node-result collection handling explicit where both shapes are possible.
- Keep the change scoped to compile-warning cleanup for the Dependabot rebase path.

## Validation

- Toolchain: Erlang/OTP 29.0.1, Elixir 1.20.0
- `MIX_ENV=test mix compile --warnings-as-errors`